### PR TITLE
Decouple logging from core

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -593,8 +593,8 @@ export const getFunctionsListForContract = (
   contractId: string
 ) => functionsMap.get(contractId) || [];
 
-const logger = (log: string) => {
-  console.log(log);
+const logger = (log: string, logLevel: "log" | "error" | "info" = "log") => {
+  console[logLevel](log);
 };
 
 const helpMessage = `
@@ -612,7 +612,7 @@ const helpMessage = `
 
 export async function main() {
   const radio = new EventEmitter();
-  radio.on("logMessage", (log) => logger(log));
+  radio.on("logMessage", (log, level = "log") => logger(log, level));
   // Get the arguments from the command-line.
   const args = process.argv;
 


### PR DESCRIPTION
This PR decouples logging from the main app logic, making it easier to maintain and extend in the future. As a result, an event emitter was added. It establishes the communication between the app and the logger, replacing all console logs with event-based logging. This PR is the first phase of #22.