### PR TITLE
Move tests to the project's root

### DIFF
--- a/app.tests.ts
+++ b/app.tests.ts
@@ -1,4 +1,4 @@
-import { main } from "../app";
+import { main } from "./app";
 
 describe("Command-line arguments handling", () => {
   const initialArgv = process.argv;

--- a/heatstroke.tests.ts
+++ b/heatstroke.tests.ts
@@ -1,6 +1,6 @@
 import fc from "fast-check";
-import { reporter } from "../heatstroke";
-import { getContractNameFromRendezvousId } from "../invariant";
+import { reporter } from "./heatstroke";
+import { getContractNameFromRendezvousId } from "./invariant";
 import { EventEmitter } from "events";
 
 describe("Custom reporter logging", () => {

--- a/invariant.tests.ts
+++ b/invariant.tests.ts
@@ -10,11 +10,11 @@ import {
   initializeClarityContext,
   initializeLocalContext,
   scheduleRendezvous,
-} from "../invariant";
+} from "./invariant";
 import {
   getFunctionsFromContractInterfaces,
   getSimnetDeployerContractsInterfaces,
-} from "../shared";
+} from "./shared";
 import { resolve } from "path";
 import fs from "fs";
 import fc from "fast-check";
@@ -23,8 +23,8 @@ import { Cl } from "@stacks/transactions";
 describe("File stream operations", () => {
   it("retrieves the invariant contract source", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
-    const contractsPath = resolve(__dirname, "../example/contracts");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
+    const contractsPath = resolve(__dirname, "./example/contracts");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const sutContractsList = Array.from(sutContractsInterfaces.keys());
@@ -51,8 +51,8 @@ describe("File stream operations", () => {
 describe("Simnet contracts operations", () => {
   it("retrieves Rendezvous contracts data", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
-    const contractsPath = resolve(__dirname, "../example/contracts");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
+    const contractsPath = resolve(__dirname, "./example/contracts");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const sutContractsList = Array.from(sutContractsInterfaces.keys());
@@ -87,8 +87,8 @@ describe("Simnet contracts operations", () => {
 
   it("deploys Rendezvous contracts to the simnet", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
-    const contractsPath = resolve(__dirname, "../example/contracts");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
+    const contractsPath = resolve(__dirname, "./example/contracts");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const sutContractsList = Array.from(sutContractsInterfaces.keys());
@@ -128,8 +128,8 @@ describe("Simnet contracts operations", () => {
 
   it("correctly filters the Rendezvous contracts interfaces", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
-    const contractsPath = resolve(__dirname, "../example/contracts");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
+    const contractsPath = resolve(__dirname, "./example/contracts");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const sutContractsList = Array.from(sutContractsInterfaces.keys());
@@ -160,7 +160,7 @@ describe("Simnet contracts operations", () => {
 
   it("correctly initializes the local context for a given functions map", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const sutContractsAllFunctions = getFunctionsFromContractInterfaces(
@@ -187,8 +187,8 @@ describe("Simnet contracts operations", () => {
 
   it("correctly initializes the Clarity context", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
-    const contractsPath = resolve(__dirname, "../example/contracts");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
+    const contractsPath = resolve(__dirname, "./example/contracts");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const sutContractsList = Array.from(sutContractsInterfaces.keys());
@@ -246,7 +246,7 @@ describe("Simnet contracts operations", () => {
 
   it("retrieves the contract source from the simnet", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const sutContractsList = Array.from(sutContractsInterfaces.keys());

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
 module.exports = {
   testEnvironment: "node",
-  testMatch: ["**/tests/**/*.test.ts"],
+  testMatch: ["**/*.tests.ts"],
   transform: {
     "^.+.tsx?$": ["ts-jest", {}],
   },

--- a/property.tests.ts
+++ b/property.tests.ts
@@ -5,8 +5,8 @@ import {
   deriveTestContractName,
   filterTestContractsInterfaces,
   getTestsContractSource,
-} from "../property";
-import { getSimnetDeployerContractsInterfaces } from "../shared";
+} from "./property";
+import { getSimnetDeployerContractsInterfaces } from "./shared";
 import { resolve } from "path";
 import fs from "fs";
 import fc from "fast-check";
@@ -14,8 +14,8 @@ import fc from "fast-check";
 describe("File stream operations", () => {
   it("retrieves the test contract source", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
-    const contractsPath = resolve(__dirname, "../example/contracts");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
+    const contractsPath = resolve(__dirname, "./example/contracts");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const sutContractsList = Array.from(sutContractsInterfaces.keys());
@@ -60,8 +60,8 @@ describe("Test contract name operations", () => {
 describe("Simnet contracts operations", () => {
   it("retrieves test contracts data", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
-    const contractsPath = resolve(__dirname, "../example/contracts");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
+    const contractsPath = resolve(__dirname, "./example/contracts");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const sutContractsList = Array.from(sutContractsInterfaces.keys());
@@ -92,8 +92,8 @@ describe("Simnet contracts operations", () => {
 
   it("deploys test contracts to the simnet", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
-    const contractsPath = resolve(__dirname, "../example/contracts");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
+    const contractsPath = resolve(__dirname, "./example/contracts");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const sutContractsList = Array.from(sutContractsInterfaces.keys());
@@ -134,8 +134,8 @@ describe("Simnet contracts operations", () => {
 
   it("correctly filters the test contracts interfaces", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
-    const contractsPath = resolve(__dirname, "../example/contracts");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
+    const contractsPath = resolve(__dirname, "./example/contracts");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const sutContractsList = Array.from(sutContractsInterfaces.keys());

--- a/shared.tests.ts
+++ b/shared.tests.ts
@@ -3,13 +3,13 @@ import {
   getFunctionsFromContractInterfaces,
   getFunctionsListForContract,
   getSimnetDeployerContractsInterfaces,
-} from "../shared";
+} from "./shared";
 import { resolve } from "path";
 
 describe("Simnet contracts operations", () => {
   it("retrieves the contracts from the simnet", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
     const simnet = await initSimnet(manifestPath);
     const expectedDeployerContracts = new Map(
       Array.from(simnet.getContractsInterfaces()).filter(
@@ -27,7 +27,7 @@ describe("Simnet contracts operations", () => {
 
   it("retrieves the contract functions from the simnet", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const sutContractsList = Array.from(sutContractsInterfaces.keys());
@@ -52,7 +52,7 @@ describe("Simnet contracts operations", () => {
 
   it("extracts the functions from the contract interfaces", async () => {
     // Arrange
-    const manifestPath = resolve(__dirname, "../example/Clarinet.toml");
+    const manifestPath = resolve(__dirname, "./example/Clarinet.toml");
     const simnet = await initSimnet(manifestPath);
     const sutContractsInterfaces = getSimnetDeployerContractsInterfaces(simnet);
     const expectedAllFunctionsMap = new Map(


### PR DESCRIPTION
This PR relocates the test files to the project root to better organize the files alongside their related test and type files. This setup keeps everything in one place, making it easier to find and manage.