### PR TITLE
Add CONTRIBUTING.md with guidelines and references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing
+
+We welcome all contributions. Big or small, every change matters.
+
+To keep things simple and to maintain quality, please follow these guidelines.
+
+## Before You Begin
+
+- Please read our `README.md` and `ACKNOWLEDGEMENTS` to understand our work.
+- Familiarize yourself with our directory structure. Each file is hand-crafted.
+- Make sure that you have Node.js LTS 20.18.0 or later.
+
+## How to Contribute
+
+1. **Open an issue:**
+   If you find a bug or want to suggest an improvement, open an issue.
+   Describe the problem and proposed changes in simple terms.
+
+2. **Create a fork and branch:**
+   Work in a dedicated branch. Use short, clear names:
+   ```
+   git checkout -b my-fix
+   ```
+
+3. **Maintain code style:**
+   We value simple, readable code. Follow our coding style:
+   - Keep line length <= 79 chars.
+   - Use simple American English.
+   - Keep comments brief and clear.
+   - Keep logic small and focused.
+
+   Example code comment:
+   ```js
+   // Good: Explains why, offering crucial context.
+   // Bad: Focuses on how or adds unnecessary verbosity.
+   ```
+
+4. **Write tests:**
+   Test your changes. Add or update tests in `*.tests.ts` files.
+   Run tests:
+   ```
+   npm test
+   ```
+
+   Make sure all tests pass before sending your changes.
+
+5. **Use clear commit messages:**
+   - Summarize changes in 79 chars or fewer.
+   - Use simple language.
+   - Example commit message:
+     ```
+     Fix off-by-one error in property-based test
+     ```
+
+   Commit messages should be short and clear.
+
+6. **Open a pull request (PR):**
+   Keep it small and focused. Explain what and why.
+   Example PR description:
+   ```
+   This PR fixes a minor off-by-one error in the property-based tests.
+   The fuzzing process now produces the expected results.
+   ```
+
+7. **Be patient and open-minded:**
+   Reviewers may ask questions or suggest changes.
+   We believe in polite and constructive discussion.
+
+## Tips for a Great Contribution
+
+- Keep your changes small and do one thing at a time.
+- Make sure your PR is easy to review.
+  Clear code and tests ease the review process.
+- Provide context for your changes. Explain why they are needed.
+- Don't rush. Take time to polish your work.
+
+## Thank You
+
+We appreciate your interest in improving Rendezvous (`rv`).
+Your contributions help keep `rv` robust, helpful, and accessible to everyone.
+
+---
+
+*This CONTRIBUTING guide is crafted with inspiration from the following:*
+
+- [AutoFixture CONTRIBUTING.md](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md) by AutoFixture contributors
+- [Hedgehog STYLE_GUIDE.md](https://github.com/hedgehogqa/haskell-hedgehog/blob/master/STYLE_GUIDE.md) by Hedgehog contributors
+- [10 Tips for Better Pull Requests](https://blog.ploeh.dk/2015/01/15/10-tips-for-better-pull-requests/) by Mark Seemann (ploeh)
+- [The Importance of Comments](https://ayende.com/blog/163297/the-importance-of-comments) by Oren Eini (Ayende Rahien)
+
+*(These references also highlight some of our roots and past influences.)*


### PR DESCRIPTION
Add CONTRIBUTING.md to guide contributors with clear guidelines, best practices, and references to works by others: Mark Seemann, Oren Eini, and contributors to AutoFixture and Hedgehog. — Markdown preview [here](https://github.com/stacks-network/rendezvous/blob/contributing/CONTRIBUTING.md).