### PR TITLE
Format all test contracts consistently

### DIFF
--- a/example/contracts/cargo.tests.clar
+++ b/example/contracts/cargo.tests.clar
@@ -4,11 +4,16 @@
   (let 
     (
       (create-shipment-num-calls
-        (default-to u0 (get called (map-get? context "create-new-shipment"))))
+        (default-to u0 (get called (map-get? context "create-new-shipment")))
+      )
     )
-    (if (> create-shipment-num-calls u0)
-        (> (var-get last-shipment-id) u0)
-        true)))
+    (if
+      (is-eq create-shipment-num-calls u0)
+      true
+      (> (var-get last-shipment-id) u0)
+    )
+  )
+)
 
 ;; Properties
 
@@ -17,90 +22,114 @@
 (define-constant ERR_CONTRACT_CALL_FAILED (err 2))
 (define-constant ERR_SHIPMENT_NOT_FOUND (err 3))
 
-(define-public (test-create-new-shipment (starting-location (string-ascii 25))
-                                         (receiver principal))
+(define-public (test-create-new-shipment
+    (starting-location (string-ascii 25))
+    (receiver principal)
+  )
   (let
     (
       (shipment-id-before (get-last-shipment-id))
-      ;; Call create-new-shipment and check the last shipment ID incremented
-      ;; by 1.
+      ;; Call create-new-shipment and assert based on the result.
       (result
         (unwrap!
           (create-new-shipment starting-location receiver)
-          ERR_CONTRACT_CALL_FAILED))
+          ERR_CONTRACT_CALL_FAILED
+        )
+      )
     )
     (asserts!
       (is-eq result "Shipment created successfully")
-      ERR_ASSERTION_FAILED)
-    (ok true)))
-
-(define-public (test-get-last-shipment-id (starting-location (string-ascii 25))
-                                          (receiver principal))
-  (let
-    (
-      (shipment-id-before (get-last-shipment-id))
+      ERR_ASSERTION_FAILED
     )
+    (ok true)
+  )
+)
+
+(define-public (test-get-last-shipment-id
+    (starting-location (string-ascii 25))
+    (receiver principal)
+  )
+  (let
+    ((shipment-id-before (get-last-shipment-id)))
     (unwrap!
       (create-new-shipment starting-location receiver)
-      ERR_CONTRACT_CALL_FAILED)
+      ERR_CONTRACT_CALL_FAILED
+    )
     ;; Verify the last shipment ID is incremented by 1.
     (asserts!
-      (is-eq
-        (get-last-shipment-id)
-        (+ shipment-id-before u1))
-      ERR_ASSERTION_FAILED)
-    (ok true)))
+      (is-eq (get-last-shipment-id) (+ u1 shipment-id-before))
+      ERR_ASSERTION_FAILED
+    )
+    (ok true)
+  )
+)
 
-(define-public (test-update-shipment (starting-location (string-ascii 25))
-                                     (receiver principal)
-                                     (new-location (string-ascii 25)))
+(define-public (test-update-shipment
+    (starting-location (string-ascii 25))
+    (receiver principal)
+    (new-location (string-ascii 25))
+  )
   (let
     (
       (create-result
         (unwrap!
           (create-new-shipment starting-location receiver)
-          ERR_CONTRACT_CALL_FAILED))
+          ERR_CONTRACT_CALL_FAILED
+        )
+      )
       (shipment-id (get-last-shipment-id))
       (update-result
         (unwrap!
           (update-shipment shipment-id new-location)
-          ERR_CONTRACT_CALL_FAILED))
+          ERR_CONTRACT_CALL_FAILED
+        )
+      )
       (updated-shipment
         (default-to
-        {
+          {
             status: "Does not exist",
             location: "Does not exist",
             shipper: tx-sender,
             receiver: tx-sender
-        }
-        (get-shipment-optional shipment-id)))
+          }
+          (get-shipment-optional shipment-id)
+        )
+      )
     )
     ;; Verify the location is updated.
     (asserts!
-      (is-eq
-        (get location updated-shipment)
-        new-location)
-      ERR_ASSERTION_FAILED)
-    (ok true)))
+      (is-eq (get location updated-shipment) new-location)
+      ERR_ASSERTION_FAILED
+    )
+    (ok true)
+  )
+)
 
-(define-public (test-get-shipment (starting-location (string-ascii 25))
-                                  (receiver principal))
+(define-public (test-get-shipment
+    (starting-location (string-ascii 25))
+    (receiver principal)
+  )
   (let
     (
       (create-result
         (unwrap!
           (create-new-shipment starting-location receiver)
-          ERR_CONTRACT_CALL_FAILED))
+          ERR_CONTRACT_CALL_FAILED
+        )
+      )
       (shipment-id (get-last-shipment-id))
       (retrieved-shipment
         (unwrap!
           (get-shipment-optional shipment-id)
-          ERR_SHIPMENT_NOT_FOUND))
+          ERR_SHIPMENT_NOT_FOUND
+        )
+      )
     )
     ;; Verify the location is correct.
     (asserts!
-      (is-eq
-        (get location retrieved-shipment)
-        starting-location)
-      ERR_ASSERTION_FAILED)
-    (ok true)))
+      (is-eq (get location retrieved-shipment) starting-location)
+      ERR_ASSERTION_FAILED
+    )
+    (ok true)
+  )
+)

--- a/example/contracts/counter.clar
+++ b/example/contracts/counter.clar
@@ -23,7 +23,7 @@
 ;; (define-public (increment)
 ;;   (let ((current-counter (var-get counter)))
 ;;     (if (> current-counter u1000) ;; Introduce a bug for large values.
-;;       (ok (var-set counter u0))   ;; Reset counter to zero if it exceeds 1000.
+;;       (ok (var-set counter u0)) ;; Reset counter to zero if it exceeds 1000.
 ;;       (ok (var-set counter (+ current-counter u1)))
 ;;     )
 ;;   )

--- a/example/contracts/counter.tests.clar
+++ b/example/contracts/counter.tests.clar
@@ -7,29 +7,54 @@
 
 (define-read-only (invariant-counter-gt-zero)
   (let
-      ((increment-num-calls (default-to u0 (get called (map-get? context "increment"))))
-       (decrement-num-calls (default-to u0 (get called (map-get? context "decrement")))))
-    (if (> increment-num-calls decrement-num-calls)
-        (> (var-get counter) u0)
-        true)))
+    (
+      (increment-num-calls
+        (default-to u0
+          (get called (map-get? context "increment"))
+        )
+      )
+      (decrement-num-calls
+        (default-to u0
+          (get called (map-get? context "decrement"))
+        )
+      )
+    )
+    (if
+      (<= increment-num-calls decrement-num-calls)
+      true
+      (> (var-get counter) u0)
+    )
+  )
+)
 
 ;; Properties
 
 ;; This test catches the bug in the counter contract.
 (define-public (test-increment)
-  (let ((counter-before (get-counter)))
+  (let
+    ((counter-before (get-counter)))
     (unwrap-panic (increment))
     (asserts! (is-eq (get-counter) (+ counter-before u1)) (err u404))
-    (ok true)))
+    (ok true)
+  )
+)
 
-;; Test that takes a parameter. This will be run using property-based techniques.
+;; Test that takes a parameter. This will be run using property-based
+;; techniques.
 (define-public (test-add (n uint))
-  (let ((counter-before (get-counter)))
-    (ok 
-      (if 
-        (> n u1)
+  (let
+    ((counter-before (get-counter)))
+    (ok
+      (if
+        (<= n u1)
+        ;; Discard the test if `add` cannot be called with the given parameter.
+        false
         (begin
           (try! (add n))
           (asserts! (is-eq (get-counter) (+ counter-before n)) (err u403))
-          true)
-        true))))
+          true
+        )
+      )
+    )
+  )
+)

--- a/example/contracts/reverse.tests.clar
+++ b/example/contracts/reverse.tests.clar
@@ -5,44 +5,49 @@
 (define-public (test-reverse (seq (list 127 int)))
   (begin
     (asserts!
-      (is-eq seq
-        (reverse
-          (reverse seq)))
-      ERR_ASSERTION_FAILED)
-    (ok true)))
+      (is-eq seq (reverse (reverse seq)))
+      ERR_ASSERTION_FAILED
+    )
+    (ok true)
+  )
+)
 
 (define-public (test-reverse-uint (seq (list 127 uint)))
   (begin
     (asserts!
-      (is-eq seq
-        (reverse-uint
-          (reverse-uint seq)))
-      ERR_ASSERTION_FAILED)
-    (ok true)))
+      (is-eq seq (reverse-uint (reverse-uint seq)))
+      ERR_ASSERTION_FAILED
+    )
+    (ok true)
+  )
+)
 
 (define-public (test-reverse-buff (seq (buff 127)))
   (begin
     (asserts!
-      (is-eq seq
-        (reverse-buff
-          (reverse-buff seq)))
-      ERR_ASSERTION_FAILED)
-    (ok true)))
+      (is-eq seq (reverse-buff (reverse-buff seq)))
+      ERR_ASSERTION_FAILED
+    )
+    (ok true)
+  )
+)
 
 (define-public (test-reverse-string (seq (string-utf8 127)))
   (begin
     (asserts!
-      (is-eq seq
-        (reverse-string
-          (reverse-string seq)))
-      ERR_ASSERTION_FAILED)
-    (ok true)))
+      (is-eq seq (reverse-string (reverse-string seq)))
+      ERR_ASSERTION_FAILED
+    )
+    (ok true)
+  )
+)
 
 (define-public (test-reverse-ascii (seq (string-ascii 127)))
   (begin
     (asserts!
-      (is-eq seq
-        (reverse-ascii
-          (reverse-ascii seq)))
-      ERR_ASSERTION_FAILED)
-    (ok true)))
+      (is-eq seq (reverse-ascii (reverse-ascii seq)))
+      ERR_ASSERTION_FAILED
+    )
+    (ok true)
+  )
+)

--- a/example/contracts/slice.tests.clar
+++ b/example/contracts/slice.tests.clar
@@ -14,17 +14,20 @@
 ;; - Name should match the property test function's, prefixed with "can-".
 ;; - Parameters should mirror those of the property test.
 ;; - Returns true only if inputs are valid, allowing the test to run.
-(define-read-only (can-test-slice-list-int (seq (list 127 int))
-                                           (skip int)
-                                           (n int))
+(define-read-only (can-test-slice-list-int
+    (seq (list 127 int))
+    (skip int)
+    (n int)
+  )
   (and
     (and (<= 0 n) (<= n 127))
-    (and (<= 0 skip) (<= skip 127))))
+    (and (<= 0 skip) (<= skip 127))
+  )
+)
 
 (define-public (test-slice-list-int (seq (list 127 int)) (skip int) (n int))
-  (let (
-      (result (slice seq skip n))
-    )
+  (let
+    ((result (slice seq skip n)))
     (if
       ;; Case 1: If skip > length of seq, result should be an empty list.
       (> (to-uint skip) (len seq))
@@ -32,17 +35,18 @@
       (if
         ;; Case 2: If n > length of seq - skip, result length should be
         ;; length of seq - skip.
-        (>
-          (to-uint n)
-          (- (len seq) (to-uint skip)))
+        (> (to-uint n) (- (len seq) (to-uint skip)))
         (asserts!
-          (is-eq
-            (len result)
-            (- (len seq) (to-uint skip)))
-          ERR_ASSERTION_FAILED_2)
+          (is-eq (len result) (- (len seq) (to-uint skip)))
+          ERR_ASSERTION_FAILED_2
+        )
         ;; Case 3: If n <= length of seq - skip, result length should be n.
-        (asserts! (is-eq (len result) (to-uint n)) ERR_ASSERTION_FAILED_3)))
-    (ok true)))
+        (asserts! (is-eq (len result) (to-uint n)) ERR_ASSERTION_FAILED_3)
+      )
+    )
+    (ok true)
+  )
+)
 
 ;; Same as 'test-slice-list-int', this test is valid only for specific
 ;; inputs. The second way to skip the test when inputs are invalid is the
@@ -53,11 +57,11 @@
     ;; Discard the test if the input is invalid by returning `(ok false)`.
     (or
       (not (and (<= 0 n) (<= n 127)))
-      (not (and (<= 0 skip) (<= skip 127))))
+      (not (and (<= 0 skip) (<= skip 127)))
+    )
     (ok false)
-    (let (
-        (result (slice-uint seq skip n))
-      )
+    (let
+      ((result (slice-uint seq skip n)))
       (if
         ;; Case 1: If skip > length of seq, result should be an empty list.
         (> (to-uint skip) (len seq))
@@ -65,28 +69,30 @@
         (if
           ;; Case 2: If n > length of seq - skip, result length should be
           ;; length of seq - skip.
-          (>
-            (to-uint n)
-            (- (len seq) (to-uint skip)))
+          (> (to-uint n) (- (len seq) (to-uint skip)))
           (asserts!
-            (is-eq
-              (len result)
-              (- (len seq) (to-uint skip)))
-            ERR_ASSERTION_FAILED_2)
+            (is-eq (len result) (- (len seq) (to-uint skip)))
+            ERR_ASSERTION_FAILED_2
+          )
           ;; Case 3: If n <= length of seq - skip, result length should be n.
-          (asserts! (is-eq (len result) (to-uint n)) ERR_ASSERTION_FAILED_3)))
-      (ok true))))
+          (asserts! (is-eq (len result) (to-uint n)) ERR_ASSERTION_FAILED_3)
+        )
+      )
+      (ok true)
+    )
+  )
+)
 
 (define-public (test-slice-list-bool (seq (list 127 bool)) (skip int) (n int))
   (if
-    ;; Early return if the input is invalid.
+    ;; Discard the test if the input is invalid.
     (or
       (not (and (<= 0 n) (<= n 127)))
-      (not (and (<= 0 skip) (<= skip 127))))
-    (ok true)
-    (let (
-        (result (slice-bool seq skip n))
-      )
+      (not (and (<= 0 skip) (<= skip 127)))
+    )
+    (ok false)
+    (let
+      ((result (slice-bool seq skip n)))
       (if
         ;; Case 1: If skip > length of seq, result should be an empty list.
         (> (to-uint skip) (len seq))
@@ -94,28 +100,30 @@
         (if
           ;; Case 2: If n > length of seq - skip, result length should be
           ;; length of seq - skip.
-          (>
-            (to-uint n)
-            (- (len seq) (to-uint skip)))
+          (> (to-uint n) (- (len seq) (to-uint skip)))
           (asserts!
-            (is-eq
-              (len result)
-              (- (len seq) (to-uint skip)))
-            ERR_ASSERTION_FAILED_2)
+            (is-eq (len result) (- (len seq) (to-uint skip)))
+            ERR_ASSERTION_FAILED_2
+          )
           ;; Case 3: If n <= length of seq - skip, result length should be n.
-          (asserts! (is-eq (len result) (to-uint n)) ERR_ASSERTION_FAILED_3)))
-      (ok true))))
+          (asserts! (is-eq (len result) (to-uint n)) ERR_ASSERTION_FAILED_3)
+        )
+      )
+      (ok true)
+    )
+  )
+)
 
 (define-public (test-slice-buff (seq (buff 127)) (skip int) (n int))
   (if
-    ;; Early return if the input is invalid.
+    ;; Discard the test if the input is invalid.
     (or
       (not (and (<= 0 n) (<= n 127)))
-      (not (and (<= 0 skip) (<= skip 127))))
-    (ok true)
-    (let (
-        (result (slice-buff seq skip n))
-      )
+      (not (and (<= 0 skip) (<= skip 127)))
+    )
+    (ok false)
+    (let
+      ((result (slice-buff seq skip n)))
       (if
         ;; Case 1: If skip > length of seq, result should be an empty list.
         (> (to-uint skip) (len seq))
@@ -123,28 +131,30 @@
         (if
           ;; Case 2: If n > length of seq - skip, result length should be
           ;; length of seq - skip.
-          (>
-            (to-uint n)
-            (- (len seq) (to-uint skip)))
+          (> (to-uint n) (- (len seq) (to-uint skip)))
           (asserts!
-            (is-eq
-              (len result)
-              (- (len seq) (to-uint skip)))
-            ERR_ASSERTION_FAILED_2)
+            (is-eq (len result) (- (len seq) (to-uint skip)))
+            ERR_ASSERTION_FAILED_2
+          )
           ;; Case 3: If n <= length of seq - skip, result length should be n.
-          (asserts! (is-eq (len result) (to-uint n)) ERR_ASSERTION_FAILED_3)))
-      (ok true))))
+          (asserts! (is-eq (len result) (to-uint n)) ERR_ASSERTION_FAILED_3)
+        )
+      )
+      (ok true)
+    )
+  )
+)
 
 (define-public (test-slice-string (seq (string-utf8 127)) (skip int) (n int))
   (if
-    ;; Early return if the input is invalid.
+    ;; Discard the test if the input is invalid.
     (or
       (not (and (<= 0 n) (<= n 127)))
-      (not (and (<= 0 skip) (<= skip 127))))
-    (ok true)
-    (let (
-        (result (slice-string seq skip n))
-      )
+      (not (and (<= 0 skip) (<= skip 127)))
+    )
+    (ok false)
+    (let
+      ((result (slice-string seq skip n)))
       (if
         ;; Case 1: If skip > length of seq, result should be an empty string.
         (> (to-uint skip) (len seq))
@@ -154,24 +164,28 @@
           ;; length of seq - skip.
           (> (to-uint n) (- (len seq) (to-uint skip)))
           (asserts!
-            (is-eq
-              (len result)
-              (- (len seq) (to-uint skip)))
-            ERR_ASSERTION_FAILED_2)
+            (is-eq (len result) (- (len seq) (to-uint skip)))
+            ERR_ASSERTION_FAILED_2
+          )
           ;; Case 3: If n <= length of seq - skip, result length should be n.
-          (asserts! (is-eq (len result) (to-uint n)) ERR_ASSERTION_FAILED_3)))
-      (ok true))))
+          (asserts! (is-eq (len result) (to-uint n)) ERR_ASSERTION_FAILED_3)
+        )
+      )
+      (ok true)
+    )
+  )
+)
 
 (define-public (test-slice-ascii (seq (string-ascii 127)) (skip int) (n int))
   (if
-    ;; Early return if the input is invalid.
+    ;; Discard the test if the input is invalid.
     (or
       (not (and (<= 0 n) (<= n 127)))
-      (not (and (<= 0 skip) (<= skip 127))))
-    (ok true)
-    (let (
-        (result (slice-ascii seq skip n))
-      )
+      (not (and (<= 0 skip) (<= skip 127)))
+    )
+    (ok false)
+    (let
+      ((result (slice-ascii seq skip n)))
       (if
         ;; Case 1: If skip > length of seq, result should be an empty string.
         (> (to-uint skip) (len seq))
@@ -181,10 +195,14 @@
           ;; length of seq - skip.
           (> (to-uint n) (- (len seq) (to-uint skip)))
           (asserts!
-            (is-eq
-              (len result)
-              (- (len seq) (to-uint skip)))
-            ERR_ASSERTION_FAILED_2)
+            (is-eq (len result) (- (len seq) (to-uint skip)))
+            ERR_ASSERTION_FAILED_2
+          )
           ;; Case 3: If n <= length of seq - skip, result length should be n.
-          (asserts! (is-eq (len result) (to-uint n)) ERR_ASSERTION_FAILED_3)))
-      (ok true))))
+          (asserts! (is-eq (len result) (to-uint n)) ERR_ASSERTION_FAILED_3)
+        )
+      )
+      (ok true)
+    )
+  )
+)


### PR DESCRIPTION
This PR ensures all test contracts follow consistent formatting rules, addressing inconsistencies in the codebase. As there is no official Clarity formatter, this PR also resolves #27.

Additionally, a minor update was made to the counter contract to align with the `max 79 chars per line` formatting rule. Tests requiring discarding were also updated as part of this PR.