### PR TITLE
Logging housekeeping

### DIFF
--- a/invariant.ts
+++ b/invariant.ts
@@ -253,11 +253,11 @@ export const checkInvariants = (
           // function's result, including any runtime errors it caused.
           radio.emit(
             "logMessage",
-            `${invariantCallerWallet} ${red(
-              "[FAIL]"
-            )} ${getContractNameFromRendezvousId(
-              r.rendezvousContractId
-            )} ${underline(r.selectedInvariant.name)} ${printedInvariantArgs}`
+            red(
+              `${invariantCallerWallet} [FAIL] ${getContractNameFromRendezvousId(
+                r.rendezvousContractId
+              )} ${underline(r.selectedInvariant.name)} ${printedInvariantArgs}`
+            )
           );
 
           // Re-throw the error for fast-check to catch and process.

--- a/property.ts
+++ b/property.ts
@@ -226,11 +226,13 @@ export const checkProperties = (
             // Capture the error and log the test failure.
             radio.emit(
               "logMessage",
-              `${dim(testCallerWallet)} ${red("[FAIL]")} ${
-                r.testContractId.split(".")[1]
-              } ${underline(
-                r.selectedTestFunction.name
-              )} ${printedTestFunctionArgs}`
+              red(
+                `${testCallerWallet} [FAIL] ${
+                  r.testContractId.split(".")[1]
+                } ${underline(
+                  r.selectedTestFunction.name
+                )} ${printedTestFunctionArgs}`
+              )
             );
 
             // Re-throw the error for fast-check to catch and process.


### PR DESCRIPTION
This PR improves the clarity of test result logs:
- Reorders log items: The log format is updated to display the function caller first, followed by the status (`[PASS]`, `[FAIL]`, `[WARN]`) for easier investigation.
- Highlights Failures: Test failure logs are now prominently displayed by highlighting them in red.

Sample output containing the two logging updates:
1. Property tests
   <img width="326" alt="image" src="https://github.com/user-attachments/assets/343da77f-1134-4c2b-a10f-3ddf0b9a0089" />
2. Invariants
   <img width="356" alt="image" src="https://github.com/user-attachments/assets/2eb42b0d-8628-4f32-8c47-41349d23ea24" />

