### PR TITLE
Optimize Simnet usage accross the app

### DIFF
--- a/invariant.ts
+++ b/invariant.ts
@@ -45,6 +45,14 @@ export const checkInvariants = (
     `\nStarting invariant testing type for the ${sutContractName} contract...`
   );
 
+  const simnetAccounts = simnet.getAccounts();
+
+  const eligibleAccounts = new Map(
+    [...simnetAccounts].filter(([key]) => key !== "faucet")
+  );
+
+  const simnetAddresses = Array.from(simnetAccounts.values());
+
   const radioReporter = (runDetails: any) => {
     reporter(runDetails, radio, "invariant");
   };
@@ -54,16 +62,8 @@ export const checkInvariants = (
       fc
         .record({
           rendezvousContractId: fc.constantFrom(...rendezvousList),
-          sutCaller: fc.constantFrom(
-            ...new Map(
-              [...simnet.getAccounts()].filter(([key]) => key !== "faucet")
-            ).entries()
-          ),
-          invariantCaller: fc.constantFrom(
-            ...new Map(
-              [...simnet.getAccounts()].filter(([key]) => key !== "faucet")
-            ).entries()
-          ),
+          sutCaller: fc.constantFrom(...eligibleAccounts.entries()),
+          invariantCaller: fc.constantFrom(...eligibleAccounts.entries()),
         })
         .chain((r) => {
           const functions = getFunctionsListForContract(
@@ -108,12 +108,12 @@ export const checkInvariants = (
         .chain((r) => {
           const functionArgsArb = functionToArbitrary(
             r.selectedFunction,
-            Array.from(simnet.getAccounts().values())
+            simnetAddresses
           );
 
           const invariantArgsArb = functionToArbitrary(
             r.selectedInvariant,
-            Array.from(simnet.getAccounts().values())
+            simnetAddresses
           );
 
           return fc

--- a/property.ts
+++ b/property.ts
@@ -84,6 +84,14 @@ export const checkProperties = (
     return;
   }
 
+  const simnetAccounts = simnet.getAccounts();
+
+  const eligibleAccounts = new Map(
+    [...simnetAccounts].filter(([key]) => key !== "faucet")
+  );
+
+  const simnetAddresses = Array.from(simnetAccounts.values());
+
   const radioReporter = (runDetails: any) => {
     reporter(runDetails, radio, "test");
   };
@@ -93,11 +101,7 @@ export const checkProperties = (
       fc
         .record({
           testContractId: fc.constantFrom(...rendezvousList),
-          testCaller: fc.constantFrom(
-            ...new Map(
-              [...simnet.getAccounts()].filter(([key]) => key !== "faucet")
-            ).entries()
-          ),
+          testCaller: fc.constantFrom(...eligibleAccounts.entries()),
         })
         .chain((r) => {
           const testFunctionsList = getFunctionsListForContract(
@@ -126,7 +130,7 @@ export const checkProperties = (
         .chain((r) => {
           const functionArgsArb = functionToArbitrary(
             r.selectedTestFunction,
-            Array.from(simnet.getAccounts().values())
+            simnetAddresses
           );
 
           return fc


### PR DESCRIPTION
This PR aims to improve Simnet efficiency in Rendezvous, enhancing overall performance and pushing the tool closer to the limits of `clarinet-sdk` `v2.12.0`. While it does not fully solve #78, it represents a step forward in optimizing resource usage.