### PR TITLE
Add burnchain advancement feature

### DIFF
--- a/app.tests.ts
+++ b/app.tests.ts
@@ -189,7 +189,7 @@ describe("Command-line arguments handling", () => {
       [
         `Using manifest path: example/Clarinet.toml`,
         `Target contract: counter`,
-        `\nStarting property testing type for the counter contract...`,
+        `\nStarting property testing type for the counter contract...\n`,
       ],
     ],
     [
@@ -198,7 +198,7 @@ describe("Command-line arguments handling", () => {
       [
         `Using manifest path: example/Clarinet.toml`,
         `Target contract: counter`,
-        `\nStarting property testing type for the counter contract...`,
+        `\nStarting property testing type for the counter contract...\n`,
       ],
     ],
     [
@@ -261,7 +261,7 @@ describe("Command-line arguments handling", () => {
         `Target contract: counter`,
         `Using seed: 123`,
         `Using path: 84:0`,
-        `\nStarting property testing type for the counter contract...`,
+        `\nStarting property testing type for the counter contract...\n`,
       ],
     ],
     [
@@ -280,7 +280,7 @@ describe("Command-line arguments handling", () => {
         `Target contract: reverse`,
         `Using seed: 123`,
         `Using path: 84:0`,
-        `\nStarting property testing type for the reverse contract...`,
+        `\nStarting property testing type for the reverse contract...\n`,
       ],
     ],
     [
@@ -299,7 +299,7 @@ describe("Command-line arguments handling", () => {
         `Target contract: slice`,
         `Using seed: 123`,
         `Using path: 84:0`,
-        `\nStarting property testing type for the slice contract...`,
+        `\nStarting property testing type for the slice contract...\n`,
       ],
     ],
     [
@@ -324,7 +324,7 @@ describe("Command-line arguments handling", () => {
         `Target contract: counter`,
         `Using seed: 123`,
         `Using path: 84:0`,
-        `\nStarting property testing type for the counter contract...`,
+        `\nStarting property testing type for the counter contract...\n`,
       ],
     ],
   ])(

--- a/app.tests.ts
+++ b/app.tests.ts
@@ -171,7 +171,7 @@ describe("Command-line arguments handling", () => {
       [
         `Using manifest path: example/Clarinet.toml`,
         `Target contract: counter`,
-        `\nStarting invariant testing type for the counter contract...`,
+        `\nStarting invariant testing type for the counter contract...\n`,
       ],
     ],
     [
@@ -180,7 +180,7 @@ describe("Command-line arguments handling", () => {
       [
         `Using manifest path: example/Clarinet.toml`,
         `Target contract: counter`,
-        `\nStarting invariant testing type for the counter contract...`,
+        `\nStarting invariant testing type for the counter contract...\n`,
       ],
     ],
     [
@@ -217,7 +217,7 @@ describe("Command-line arguments handling", () => {
         `Target contract: counter`,
         `Using seed: 123`,
         `Using path: 84:0`,
-        `\nStarting invariant testing type for the counter contract...`,
+        `\nStarting invariant testing type for the counter contract...\n`,
       ],
     ],
     [
@@ -242,7 +242,7 @@ describe("Command-line arguments handling", () => {
         `Target contract: counter`,
         `Using seed: 123`,
         `Using path: 84:0`,
-        `\nStarting invariant testing type for the counter contract...`,
+        `\nStarting invariant testing type for the counter contract...\n`,
       ],
     ],
     [

--- a/invariant.ts
+++ b/invariant.ts
@@ -64,7 +64,7 @@ export const checkInvariants = (
           rendezvousContractId: fc.constantFrom(...rendezvousList),
           sutCaller: fc.constantFrom(...eligibleAccounts.entries()),
           invariantCaller: fc.constantFrom(...eligibleAccounts.entries()),
-          mineBurnBlocks: fc.boolean(),
+          canMineBlocks: fc.boolean(),
         })
         .chain((r) => {
           const functions = getFunctionsListForContract(
@@ -127,11 +127,11 @@ export const checkInvariants = (
         .chain((r) =>
           fc
             .record({
-              burnBlocksToMine: r.mineBurnBlocks
+              burnBlocks: r.canMineBlocks
                 ? fc.integer({ min: 1, max: 10 })
                 : fc.constant(0),
             })
-            .map((burnBlocksToMine) => ({ ...r, ...burnBlocksToMine }))
+            .map((burnBlocks) => ({ ...r, ...burnBlocks }))
         ),
       (r) => {
         const selectedFunctionArgs = argsToCV(
@@ -292,8 +292,8 @@ export const checkInvariants = (
         }
 
         try {
-          if (r.mineBurnBlocks) {
-            simnet.mineEmptyBurnBlocks(r.burnBlocksToMine);
+          if (r.canMineBlocks) {
+            simnet.mineEmptyBurnBlocks(r.burnBlocks);
           }
         } catch (error: any) {
           throw error;

--- a/invariant.ts
+++ b/invariant.ts
@@ -128,7 +128,16 @@ export const checkInvariants = (
           fc
             .record({
               burnBlocks: r.canMineBlocks
-                ? fc.integer({ min: 1, max: 10 })
+                ? // This arbitrary produces integers with a maximum value
+                  // inversely proportional to the number of runs:
+                  // - Fewer runs result in a higher maximum burn blocks,
+                  //   allowing more blocks to be mined.
+                  // - More runs result in a lower maximum burn blocks, as more
+                  //   blocks are mined overall.
+                  fc.integer({
+                    min: 1,
+                    max: Math.ceil(100_000 / (runs || 100)),
+                  })
                 : fc.constant(0),
             })
             .map((burnBlocks) => ({ ...r, ...burnBlocks }))

--- a/invariant.ts
+++ b/invariant.ts
@@ -291,12 +291,8 @@ export const checkInvariants = (
           throw error;
         }
 
-        try {
-          if (r.canMineBlocks) {
-            simnet.mineEmptyBurnBlocks(r.burnBlocks);
-          }
-        } catch (error: any) {
-          throw error;
+        if (r.canMineBlocks) {
+          simnet.mineEmptyBurnBlocks(r.burnBlocks);
         }
       }
     ),

--- a/invariant.ts
+++ b/invariant.ts
@@ -193,8 +193,8 @@ export const checkInvariants = (
 
             radio.emit(
               "logMessage",
-              `₿ ${simnet.burnBlockHeight.toString().padStart(6)} ` +
-                `Ӿ ${simnet.blockHeight.toString().padStart(6)}   ` +
+              `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
+                `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                 dim(`${sutCallerWallet}        `) +
                 `${getContractNameFromRendezvousId(r.rendezvousContractId)} ` +
                 `${underline(r.selectedFunction.name)} ` +
@@ -204,8 +204,8 @@ export const checkInvariants = (
             radio.emit(
               "logMessage",
               dim(
-                `₿ ${simnet.burnBlockHeight.toString().padStart(6)} ` +
-                  `Ӿ ${simnet.blockHeight.toString().padStart(6)}   ` +
+                `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
+                  `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                   `${sutCallerWallet}        ` +
                   `${getContractNameFromRendezvousId(
                     r.rendezvousContractId
@@ -222,8 +222,8 @@ export const checkInvariants = (
           radio.emit(
             "logMessage",
             dim(
-              `₿ ${simnet.burnBlockHeight.toString().padStart(6)} ` +
-                `Ӿ ${simnet.blockHeight.toString().padStart(6)}   ` +
+              `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
+                `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                 `${sutCallerWallet}        ` +
                 `${getContractNameFromRendezvousId(r.rendezvousContractId)} ` +
                 `${underline(r.selectedFunction.name)} ` +
@@ -260,8 +260,8 @@ export const checkInvariants = (
           if (invariantCallResultJson.value === true) {
             radio.emit(
               "logMessage",
-              `₿ ${simnet.burnBlockHeight.toString().padStart(6)} ` +
-                `Ӿ ${simnet.blockHeight.toString().padStart(6)}   ` +
+              `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
+                `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                 `${dim(invariantCallerWallet)} ` +
                 `${green("[PASS]")} ` +
                 `${getContractNameFromRendezvousId(r.rendezvousContractId)} ` +
@@ -286,8 +286,8 @@ export const checkInvariants = (
           radio.emit(
             "logMessage",
             red(
-              `₿ ${simnet.burnBlockHeight.toString().padStart(6)} ` +
-                `Ӿ ${simnet.blockHeight.toString().padStart(6)}   ` +
+              `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
+                `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                 `${invariantCallerWallet} ` +
                 `[FAIL] ` +
                 `${getContractNameFromRendezvousId(r.rendezvousContractId)} ` +

--- a/property.ts
+++ b/property.ts
@@ -102,7 +102,7 @@ export const checkProperties = (
         .record({
           testContractId: fc.constantFrom(...rendezvousList),
           testCaller: fc.constantFrom(...eligibleAccounts.entries()),
-          mineBurnBlocks: fc.boolean(),
+          canMineBlocks: fc.boolean(),
         })
         .chain((r) => {
           const testFunctionsList = getFunctionsListForContract(
@@ -143,11 +143,11 @@ export const checkProperties = (
         .chain((r) =>
           fc
             .record({
-              burnBlocksToMine: r.mineBurnBlocks
+              burnBlocks: r.canMineBlocks
                 ? fc.integer({ min: 1, max: 10 })
                 : fc.constant(0),
             })
-            .map((burnBlocksToMine) => ({ ...r, ...burnBlocksToMine }))
+            .map((burnBlocks) => ({ ...r, ...burnBlocks }))
         ),
       (r) => {
         const selectedTestFunctionArgs = argsToCV(
@@ -236,8 +236,8 @@ export const checkProperties = (
                   printedTestFunctionArgs
               );
 
-              if (r.mineBurnBlocks) {
-                simnet.mineEmptyBurnBlocks(r.burnBlocksToMine);
+              if (r.canMineBlocks) {
+                simnet.mineEmptyBurnBlocks(r.burnBlocks);
               }
             } else {
               throw new Error(

--- a/property.ts
+++ b/property.ts
@@ -144,7 +144,16 @@ export const checkProperties = (
           fc
             .record({
               burnBlocks: r.canMineBlocks
-                ? fc.integer({ min: 1, max: 10 })
+                ? // This arbitrary produces integers with a maximum value
+                  // inversely proportional to the number of runs:
+                  // - Fewer runs result in a higher maximum burn blocks,
+                  //   allowing more blocks to be mined.
+                  // - More runs result in a lower maximum burn blocks, as more
+                  //   blocks are mined overall.
+                  fc.integer({
+                    min: 1,
+                    max: Math.ceil(100_000 / (runs || 100)),
+                  })
                 : fc.constant(0),
             })
             .map((burnBlocks) => ({ ...r, ...burnBlocks }))

--- a/property.ts
+++ b/property.ts
@@ -193,8 +193,8 @@ export const checkProperties = (
         if (discarded) {
           radio.emit(
             "logMessage",
-            `₿ ${simnet.burnBlockHeight.toString().padStart(6)} ` +
-              `Ӿ ${simnet.blockHeight.toString().padStart(6)}   ` +
+            `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
+              `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
               `${dim(testCallerWallet)} ` +
               `${yellow("[WARN]")} ` +
               `${r.testContractId.split(".")[1]} ` +
@@ -221,8 +221,8 @@ export const checkProperties = (
             if (discardedInPlace) {
               radio.emit(
                 "logMessage",
-                `₿ ${simnet.burnBlockHeight.toString().padStart(6)} ` +
-                  `Ӿ ${simnet.blockHeight.toString().padStart(6)}   ` +
+                `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
+                  `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                   `${dim(testCallerWallet)} ` +
                   `${yellow("[WARN]")} ` +
                   `${r.testContractId.split(".")[1]} ` +
@@ -236,8 +236,8 @@ export const checkProperties = (
             ) {
               radio.emit(
                 "logMessage",
-                `₿ ${simnet.burnBlockHeight.toString().padStart(6)} ` +
-                  `Ӿ ${simnet.blockHeight.toString().padStart(6)}   ` +
+                `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
+                  `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                   `${dim(testCallerWallet)} ` +
                   `${green("[PASS]")} ` +
                   `${r.testContractId.split(".")[1]} ` +
@@ -260,8 +260,8 @@ export const checkProperties = (
             radio.emit(
               "logMessage",
               red(
-                `₿ ${simnet.burnBlockHeight.toString().padStart(6)} ` +
-                  `Ӿ ${simnet.blockHeight.toString().padStart(6)}   ` +
+                `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
+                  `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                   `${testCallerWallet} ` +
                   `[FAIL] ` +
                   `${r.testContractId.split(".")[1]} ` +


### PR DESCRIPTION
This PR introduces a seed-based method for advancing the burnchain in both invariant and property testing. Logs now display the current Stacks and Bitcoin block heights.

**Sample Output:**
```
# type=test

₿      1 Ӿ      6   wallet_4 [PASS] reverse test-reverse-string 
₿      1 Ӿ      7   wallet_7 [PASS] reverse test-reverse [1764733795]
₿      2 Ӿ      9   wallet_7 [PASS] reverse test-reverse-string toLoc
₿      2 Ӿ     10   wallet_3 [PASS] reverse test-reverse-string 7H0/t
₿      3 Ӿ     12   wallet_5 [PASS] reverse test-reverse-string -
```
```
# type=invariant

₿     48 Ӿ     95   deployer [PASS] counter invariant-counter-gt-zero 
₿     48 Ӿ     97   wallet_5        counter decrement 
₿     48 Ӿ     97   wallet_5 [PASS] counter invariant-counter-gt-zero 
₿     57 Ӿ    108   wallet_5        counter increment 
₿     57 Ӿ    108   wallet_8 [PASS] counter invariant-counter-gt-zero 
₿     57 Ӿ    110   deployer        counter add 2147483639
₿     57 Ӿ    110   wallet_4 [PASS] counter invariant-counter-gt-zero 
₿     57 Ӿ    112   wallet_2        counter increment 
₿     57 Ӿ    112   wallet_7 [PASS] counter invariant-counter-gt-zero 
₿     62 Ӿ    119   wallet_3        counter add 6
₿     62 Ӿ    119   wallet_7 [PASS] counter invariant-counter-gt-zero
```

Resolves #76.