### PR TITLE
Bump version to `0.1.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rendezvous",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rendezvous",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "GPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rendezvous",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Meet your contract's vulnerabilities head-on.",
   "main": "app.js",
   "bin": {


### PR DESCRIPTION
This PR bumps `Rendezvous` version to `0.1.0`.