### PR TITLE
Skip functions with `trait reference` parameters from selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [22, 20, 18]
+        node: [23, 22, 20, 18]
 
     steps:
       - name: Checkout code
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [22, 20, 18]
+        node: [23, 22, 20, 18]
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 deployments
 dist
+coverage

--- a/app.tests.ts
+++ b/app.tests.ts
@@ -1,3 +1,4 @@
+import { red } from "ansicolor";
 import { main } from "./app";
 import { version } from "./package.json";
 
@@ -20,8 +21,12 @@ describe("Command-line arguments handling", () => {
     --runs - The runs to use for iterating over the tests. Default: 100.
     --help - Show the help message.
   `;
-  const noManifestMessage = `\nNo path to Clarinet project provided. Supply it immediately or face the relentless scrutiny of your contract's vulnerabilities.`;
-  const noContractNameMessage = `\nNo target contract name provided. Please provide the contract name to be fuzzed.`;
+  const noManifestMessage = red(
+    `\nNo path to Clarinet project provided. Supply it immediately or face the relentless scrutiny of your contract's vulnerabilities.`
+  );
+  const noContractNameMessage = red(
+    `\nNo target contract name provided. Please provide the contract name to be fuzzed.`
+  );
 
   it.each([
     ["manifest path", ["node", "app.js"]],
@@ -96,24 +101,20 @@ describe("Command-line arguments handling", () => {
     [
       ["no command-line arguments"],
       ["node", "app.js"],
-      [
-        `\nNo path to Clarinet project provided. Supply it immediately or face the relentless scrutiny of your contract's vulnerabilities.`,
-        helpMessage,
-      ],
+      [noManifestMessage, helpMessage],
     ],
     [
       ["manifest path"],
       ["node", "app.js", "example"],
-      [
-        `\nNo target contract name provided. Please provide the contract name to be fuzzed.`,
-        helpMessage,
-      ],
+      [noContractNameMessage, helpMessage],
     ],
     [
       ["manifest path", "contract name"],
       ["node", "app.js", "example", "counter"],
       [
-        `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`,
+        red(
+          `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`
+        ),
         helpMessage,
       ],
     ],
@@ -121,7 +122,9 @@ describe("Command-line arguments handling", () => {
       ["manifest path", "contract name", "seed"],
       ["node", "app.js", "example", "counter", "--seed=123"],
       [
-        `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`,
+        red(
+          `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`
+        ),
         helpMessage,
       ],
     ],
@@ -129,7 +132,9 @@ describe("Command-line arguments handling", () => {
       ["manifest path", "contract name", "seed", "path"],
       ["node", "app.js", "example", "counter", "--seed=123", "--path=84:0"],
       [
-        `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`,
+        red(
+          `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`
+        ),
         helpMessage,
       ],
     ],
@@ -137,7 +142,9 @@ describe("Command-line arguments handling", () => {
       ["manifest path", "contract name", "runs"],
       ["node", "app.js", "example", "counter", "--runs=10"],
       [
-        `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`,
+        red(
+          `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`
+        ),
         helpMessage,
       ],
     ],
@@ -145,7 +152,9 @@ describe("Command-line arguments handling", () => {
       ["manifest path", "contract name", "path"],
       ["node", "app.js", "example", "counter", "--path=84:0"],
       [
-        `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`,
+        red(
+          `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`
+        ),
         helpMessage,
       ],
     ],
@@ -161,7 +170,9 @@ describe("Command-line arguments handling", () => {
         "--runs=10",
       ],
       [
-        `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`,
+        red(
+          `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`
+        ),
         helpMessage,
       ],
     ],

--- a/app.ts
+++ b/app.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from "events";
 import { checkProperties } from "./property";
 import { checkInvariants } from "./invariant";
 import {
+  getContractNameFromContractId,
   getFunctionsFromContractInterfaces,
   getSimnetDeployerContractsInterfaces,
 } from "./shared";
@@ -117,7 +118,7 @@ export async function main() {
   const rendezvousList = Array.from(
     getSimnetDeployerContractsInterfaces(simnet).keys()
   ).filter((deployedContract) =>
-    [sutContractName].includes(deployedContract.split(".")[1])
+    [sutContractName].includes(getContractNameFromContractId(deployedContract))
   );
 
   const rendezvousAllFunctions = getFunctionsFromContractInterfaces(

--- a/app.ts
+++ b/app.ts
@@ -9,6 +9,7 @@ import {
 } from "./shared";
 import { issueFirstClassCitizenship } from "./citizen";
 import { version } from "./package.json";
+import { red } from "ansicolor";
 
 const logger = (log: string, logLevel: "log" | "error" | "info" = "log") => {
   console[logLevel](log);
@@ -42,7 +43,7 @@ const parseOptionalArgument = (argName: string) => {
 export async function main() {
   const radio = new EventEmitter();
   radio.on("logMessage", (log) => logger(log));
-  radio.on("logFailure", (log) => logger(log, "error"));
+  radio.on("logFailure", (log) => logger(red(log), "error"));
 
   const args = process.argv;
   if (args.includes("--help")) {
@@ -55,7 +56,9 @@ export async function main() {
   if (!manifestDir || manifestDir.startsWith("--")) {
     radio.emit(
       "logMessage",
-      "\nNo path to Clarinet project provided. Supply it immediately or face the relentless scrutiny of your contract's vulnerabilities."
+      red(
+        "\nNo path to Clarinet project provided. Supply it immediately or face the relentless scrutiny of your contract's vulnerabilities."
+      )
     );
     radio.emit("logMessage", helpMessage);
     return;
@@ -66,7 +69,9 @@ export async function main() {
   if (!sutContractName || sutContractName.startsWith("--")) {
     radio.emit(
       "logMessage",
-      "\nNo target contract name provided. Please provide the contract name to be fuzzed."
+      red(
+        "\nNo target contract name provided. Please provide the contract name to be fuzzed."
+      )
     );
     radio.emit("logMessage", helpMessage);
     return;
@@ -76,7 +81,9 @@ export async function main() {
   if (!type || type.startsWith("--") || !["test", "invariant"].includes(type)) {
     radio.emit(
       "logMessage",
-      "\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant."
+      red(
+        "\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant."
+      )
     );
     radio.emit("logMessage", helpMessage);
     return;

--- a/heatstroke.tests.ts
+++ b/heatstroke.tests.ts
@@ -3,6 +3,7 @@ import { reporter } from "./heatstroke";
 import { EventEmitter } from "events";
 import { resolve } from "path";
 import { initSimnet } from "@hirosystems/clarinet-sdk";
+import { getContractNameFromContractId } from "./shared";
 
 describe("Custom reporter logging", () => {
   it("handles cases with missing path on failure for invariant testing type", async () => {
@@ -104,7 +105,9 @@ describe("Custom reporter logging", () => {
             `\nError: Property failed after ${r.numRuns} tests.`,
             `Seed : ${r.seed}`,
             `\nCounterexample:`,
-            `- Contract : ${rendezvousContractId.split(".")[1]}`,
+            `- Contract : ${getContractNameFromContractId(
+              rendezvousContractId
+            )}`,
             `- Function : ${r.selectedFunction.name} (${r.selectedFunction.access})`,
             `- Arguments: ${JSON.stringify(r.functionArgsArb)}`,
             `- Caller   : ${r.sutCaller[0]}`,
@@ -232,7 +235,9 @@ describe("Custom reporter logging", () => {
             `Seed : ${r.seed}`,
             `Path : ${r.path}`,
             `\nCounterexample:`,
-            `- Contract : ${rendezvousContractId.split(".")[1]}`,
+            `- Contract : ${getContractNameFromContractId(
+              rendezvousContractId
+            )}`,
             `- Function : ${r.selectedFunction.name} (${r.selectedFunction.access})`,
             `- Arguments: ${JSON.stringify(r.functionArgsArb)}`,
             `- Caller   : ${r.sutCaller[0]}`,
@@ -439,7 +444,9 @@ describe("Custom reporter logging", () => {
             `\nError: Property failed after ${r.numRuns} tests.`,
             `Seed : ${r.seed}`,
             `\nCounterexample:`,
-            `- Test Contract : ${testContractId.split(".")[1]}`,
+            `- Test Contract : ${getContractNameFromContractId(
+              testContractId
+            )}`,
             `- Test Function : ${r.selectedTestFunction.name} (${r.selectedTestFunction.access})`,
             `- Arguments     : ${JSON.stringify(r.functionArgsArb)}`,
             `- Caller        : ${r.testCaller[0]}`,
@@ -542,7 +549,9 @@ describe("Custom reporter logging", () => {
             `Seed : ${r.seed}`,
             `Path : ${r.path}`,
             `\nCounterexample:`,
-            `- Test Contract : ${testContractId.split(".")[1]}`,
+            `- Test Contract : ${getContractNameFromContractId(
+              testContractId
+            )}`,
             `- Test Function : ${r.selectedTestFunction.name} (${r.selectedTestFunction.access})`,
             `- Arguments     : ${JSON.stringify(r.functionArgsArb)}`,
             `- Caller        : ${r.testCaller[0]}`,

--- a/heatstroke.tests.ts
+++ b/heatstroke.tests.ts
@@ -1,6 +1,5 @@
 import fc from "fast-check";
 import { reporter } from "./heatstroke";
-import { getContractNameFromRendezvousId } from "./invariant";
 import { EventEmitter } from "events";
 import { resolve } from "path";
 import { initSimnet } from "@hirosystems/clarinet-sdk";
@@ -105,9 +104,7 @@ describe("Custom reporter logging", () => {
             `\nError: Property failed after ${r.numRuns} tests.`,
             `Seed : ${r.seed}`,
             `\nCounterexample:`,
-            `- Contract : ${getContractNameFromRendezvousId(
-              rendezvousContractId
-            )}`,
+            `- Contract : ${rendezvousContractId.split(".")[1]}`,
             `- Function : ${r.selectedFunction.name} (${r.selectedFunction.access})`,
             `- Arguments: ${JSON.stringify(r.functionArgsArb)}`,
             `- Caller   : ${r.sutCaller[0]}`,
@@ -235,9 +232,7 @@ describe("Custom reporter logging", () => {
             `Seed : ${r.seed}`,
             `Path : ${r.path}`,
             `\nCounterexample:`,
-            `- Contract : ${getContractNameFromRendezvousId(
-              rendezvousContractId
-            )}`,
+            `- Contract : ${rendezvousContractId.split(".")[1]}`,
             `- Function : ${r.selectedFunction.name} (${r.selectedFunction.access})`,
             `- Arguments: ${JSON.stringify(r.functionArgsArb)}`,
             `- Caller   : ${r.sutCaller[0]}`,

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -25,6 +25,7 @@
 
 import { green } from "ansicolor";
 import { EventEmitter } from "events";
+import { getContractNameFromContractId } from "./shared";
 
 export function reporter(
   //@ts-ignore
@@ -50,7 +51,9 @@ export function reporter(
         radio.emit("logFailure", `\nCounterexample:`);
         radio.emit(
           "logFailure",
-          `- Contract : ${r.rendezvousContractId.split(".")[1]}`
+          `- Contract : ${getContractNameFromContractId(
+            r.rendezvousContractId
+          )}`
         );
         radio.emit(
           "logFailure",
@@ -98,7 +101,7 @@ export function reporter(
         radio.emit("logFailure", `\nCounterexample:`);
         radio.emit(
           "logFailure",
-          `- Test Contract : ${r.testContractId.split(".")[1]}`
+          `- Test Contract : ${getContractNameFromContractId(r.testContractId)}`
         );
         radio.emit(
           "logFailure",

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -23,9 +23,8 @@
  * @property runDetails.error - The error thrown during the test.
  */
 
-import { EventEmitter } from "events";
-import { getContractNameFromRendezvousId } from "./invariant";
 import { green } from "ansicolor";
+import { EventEmitter } from "events";
 
 export function reporter(
   //@ts-ignore
@@ -51,9 +50,7 @@ export function reporter(
         radio.emit("logFailure", `\nCounterexample:`);
         radio.emit(
           "logFailure",
-          `- Contract : ${getContractNameFromRendezvousId(
-            r.rendezvousContractId
-          )}`
+          `- Contract : ${r.rendezvousContractId.split(".")[1]}`
         );
         radio.emit(
           "logFailure",
@@ -138,9 +135,11 @@ export function reporter(
   } else {
     radio.emit(
       "logMessage",
+      green(
         `\nOK, ${
           type === "invariant" ? "invariants" : "properties"
         } passed after ${runDetails.numRuns} runs.\n`
+      )
     );
   }
 }

--- a/invariant.tests.ts
+++ b/invariant.tests.ts
@@ -1,6 +1,7 @@
 import { initSimnet } from "@hirosystems/clarinet-sdk";
 import { initializeClarityContext, initializeLocalContext } from "./invariant";
 import {
+  getContractNameFromContractId,
   getFunctionsFromContractInterfaces,
   getSimnetDeployerContractsInterfaces,
 } from "./shared";
@@ -43,7 +44,7 @@ describe("Simnet contracts operations", () => {
     const rendezvousList = Array.from(
       getSimnetDeployerContractsInterfaces(simnet).keys()
     ).filter((deployedContract) =>
-      ["counter"].includes(deployedContract.split(".")[1])
+      ["counter"].includes(getContractNameFromContractId(deployedContract))
     );
 
     const rendezvousAllFunctions = getFunctionsFromContractInterfaces(

--- a/invariant.tests.ts
+++ b/invariant.tests.ts
@@ -1,9 +1,5 @@
 import { initSimnet } from "@hirosystems/clarinet-sdk";
-import {
-  getContractNameFromRendezvousId,
-  initializeClarityContext,
-  initializeLocalContext,
-} from "./invariant";
+import { initializeClarityContext, initializeLocalContext } from "./invariant";
 import {
   getFunctionsFromContractInterfaces,
   getSimnetDeployerContractsInterfaces,
@@ -11,7 +7,6 @@ import {
 import { join } from "path";
 import { issueFirstClassCitizenship } from "./citizen";
 import { Cl } from "@stacks/transactions";
-import fc from "fast-check";
 
 describe("Simnet contracts operations", () => {
   it("correctly initializes the local context for a given functions map", async () => {
@@ -95,29 +90,5 @@ describe("Simnet contracts operations", () => {
     );
 
     expect(actualContext).toEqual(expectedContext);
-  });
-});
-
-describe("Rendezvous contract name", () => {
-  it("gets contract name from Rendezvous contract name", () => {
-    const addressCharset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    const contractNameCharset =
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-    fc.assert(
-      // Arrange
-      fc.property(
-        fc.stringOf(fc.constantFrom(...addressCharset)),
-        fc.stringOf(fc.constantFrom(...contractNameCharset)),
-        (address, contractName) => {
-          const rendezvousId = `${address}.${contractName}_rendezvous`;
-
-          // Act
-          const actual = getContractNameFromRendezvousId(rendezvousId);
-
-          // Assert
-          expect(actual).toBe(contractName);
-        }
-      )
-    );
   });
 });

--- a/invariant.ts
+++ b/invariant.ts
@@ -69,19 +69,23 @@ export const checkInvariants = (
   );
 
   if (functions?.length === 0) {
-    throw new Error(
-      `No public functions found for the "${getContractNameFromRendezvousId(
-        rendezvousContractId
-      )}" contract.`
+    radio.emit(
+      "logMessage",
+      red(
+        `No public functions found for the "${sutContractName}" contract. Without public functions, no state transitions can happen inside the contract, and the invariant test is not meaningful.\n`
+      )
     );
+    return;
   }
 
   if (invariantFunctions?.length === 0) {
-    throw new Error(
-      `No invariant functions found for the "${getContractNameFromRendezvousId(
-        rendezvousContractId
-      )}" contract. Beware, for your contract may be exposed to unforeseen issues.`
+    radio.emit(
+      "logMessage",
+      red(
+        `No invariant functions found for the "${sutContractName}" contract. Beware, for your contract may be exposed to unforeseen issues.\n`
+      )
     );
+    return;
   }
 
   const eligibleFunctions = functions.filter(
@@ -93,19 +97,23 @@ export const checkInvariants = (
   );
 
   if (eligibleFunctions.length === 0) {
-    throw new Error(
-      `No eligible public functions found for the "${getContractNameFromRendezvousId(
-        rendezvousContractId
-      )}" contract. Note: trait references are not supported.`
+    radio.emit(
+      "logMessage",
+      red(
+        `No eligible public functions found for the "${sutContractName}" contract. Note: trait references are not supported.\n`
+      )
     );
+    return;
   }
 
   if (eligibleInvariants.length === 0) {
-    throw new Error(
-      `No eligible invariant functions found for the "${getContractNameFromRendezvousId(
-        rendezvousContractId
-      )}" contract. Note: trait references are not supported.`
+    radio.emit(
+      "logMessage",
+      red(
+        `No eligible invariant functions found for the "${sutContractName}" contract. Note: trait references are not supported.\n`
+      )
     );
+    return;
   }
 
   const radioReporter = (runDetails: any) => {
@@ -218,7 +226,7 @@ export const checkInvariants = (
               `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
                 `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                 dim(`${sutCallerWallet}        `) +
-                `${getContractNameFromRendezvousId(r.rendezvousContractId)} ` +
+                `${sutContractName} ` +
                 `${underline(r.selectedFunction.name)} ` +
                 printedFunctionArgs
             );
@@ -229,9 +237,7 @@ export const checkInvariants = (
                 `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
                   `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                   `${sutCallerWallet}        ` +
-                  `${getContractNameFromRendezvousId(
-                    r.rendezvousContractId
-                  )} ` +
+                  `${sutContractName} ` +
                   `${underline(r.selectedFunction.name)} ` +
                   printedFunctionArgs
               )
@@ -247,7 +253,7 @@ export const checkInvariants = (
               `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
                 `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                 `${sutCallerWallet}        ` +
-                `${getContractNameFromRendezvousId(r.rendezvousContractId)} ` +
+                `${sutContractName} ` +
                 `${underline(r.selectedFunction.name)} ` +
                 printedFunctionArgs
             )
@@ -286,7 +292,7 @@ export const checkInvariants = (
                 `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                 `${dim(invariantCallerWallet)} ` +
                 `${green("[PASS]")} ` +
-                `${getContractNameFromRendezvousId(r.rendezvousContractId)} ` +
+                `${sutContractName} ` +
                 `${underline(r.selectedInvariant.name)} ` +
                 printedInvariantArgs
             );
@@ -294,11 +300,7 @@ export const checkInvariants = (
 
           if (!invariantCallResultJson.value) {
             throw new Error(
-              `Invariant failed for ${getContractNameFromRendezvousId(
-                r.rendezvousContractId
-              )} contract: "${r.selectedInvariant.name}" returned ${
-                invariantCallResultJson.value
-              }`
+              `Invariant failed for ${sutContractName} contract: "${r.selectedInvariant.name}" returned ${invariantCallResultJson.value}`
             );
           }
         } catch (error: any) {
@@ -312,7 +314,7 @@ export const checkInvariants = (
                 `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                 `${invariantCallerWallet} ` +
                 `[FAIL] ` +
-                `${getContractNameFromRendezvousId(r.rendezvousContractId)} ` +
+                `${sutContractName} ` +
                 `${underline(r.selectedInvariant.name)} ` +
                 printedInvariantArgs
             )
@@ -375,14 +377,6 @@ export const initializeClarityContext = (
       }
     });
   });
-
-/**
- * Get the contract name from the Rendezvous identifier.
- * @param rendezvousId The Rendezvous contract identifier.
- * @returns The contract name.
- */
-export const getContractNameFromRendezvousId = (rendezvousId: string) =>
-  rendezvousId.split(".")[1].replace("_rendezvous", "");
 
 /**
  * Filter the System Under Test (`SUT`) functions from the map of all

--- a/invariant.ts
+++ b/invariant.ts
@@ -136,8 +136,6 @@ export const checkInvariants = (
           fc
             .record({
               selectedFunction: fc.constantFrom(...eligibleFunctions),
-              // FIXME: For invariants, we have to be able to select a random
-              // number of them (zero or more).
               selectedInvariant: fc.constantFrom(...eligibleInvariants),
             })
             .map((selectedFunctions) => ({ ...r, ...selectedFunctions }))

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "postinstall": "npx -p typescript tsc --project tsconfig.json && node -e \"if (process.platform !== 'win32') require('fs').chmodSync('./dist/app.js', 0o755);\"",
-    "test": "npx tsc --project tsconfig.json && npx jest"
+    "test": "npx tsc --project tsconfig.json && npx jest",
+    "test:coverage": "npx tsc --project tsconfig.json && npx jest --coverage"
   },
   "keywords": [
     "stacks",

--- a/property.ts
+++ b/property.ts
@@ -6,6 +6,7 @@ import { reporter } from "./heatstroke";
 import {
   argsToCV,
   functionToArbitrary,
+  getContractNameFromContractId,
   getFunctionsListForContract,
   isTraitReferenceFunction,
 } from "./shared";
@@ -212,7 +213,7 @@ export const checkProperties = (
               `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
               `${dim(testCallerWallet)} ` +
               `${yellow("[WARN]")} ` +
-              `${r.testContractId.split(".")[1]} ` +
+              `${sutContractName} ` +
               `${underline(r.selectedTestFunction.name)} ` +
               dim(printedTestFunctionArgs)
           );
@@ -240,7 +241,7 @@ export const checkProperties = (
                   `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                   `${dim(testCallerWallet)} ` +
                   `${yellow("[WARN]")} ` +
-                  `${r.testContractId.split(".")[1]} ` +
+                  `${sutContractName} ` +
                   `${underline(r.selectedTestFunction.name)} ` +
                   dim(printedTestFunctionArgs)
               );
@@ -255,7 +256,7 @@ export const checkProperties = (
                   `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                   `${dim(testCallerWallet)} ` +
                   `${green("[PASS]")} ` +
-                  `${r.testContractId.split(".")[1]} ` +
+                  `${sutContractName} ` +
                   `${underline(r.selectedTestFunction.name)} ` +
                   printedTestFunctionArgs
               );
@@ -265,9 +266,7 @@ export const checkProperties = (
               }
             } else {
               throw new Error(
-                `Test failed for ${r.testContractId.split(".")[1]} contract: "${
-                  r.selectedTestFunction.name
-                }" returned ${testFunctionCallResultJson.value.value}`
+                `Test failed for ${sutContractName} contract: "${r.selectedTestFunction.name}" returned ${testFunctionCallResultJson.value.value}`
               );
             }
           } catch (error: any) {
@@ -279,7 +278,7 @@ export const checkProperties = (
                   `Ӿ ${simnet.blockHeight.toString().padStart(8)}   ` +
                   `${testCallerWallet} ` +
                   `[FAIL] ` +
-                  `${r.testContractId.split(".")[1]} ` +
+                  `${sutContractName} ` +
                   `${underline(r.selectedTestFunction.name)} ` +
                   printedTestFunctionArgs
               )
@@ -377,9 +376,9 @@ const validateDiscardFunction = (
     radio.emit(
       "logMessage",
       red(
-        `\nError: Parameter mismatch for discard function "${discardFunctionName}" in contract "${
-          contractId.split(".")[1]
-        }".\n`
+        `\nError: Parameter mismatch for discard function "${discardFunctionName}" in contract "${getContractNameFromContractId(
+          contractId
+        )}".\n`
       )
     );
     return false;
@@ -389,9 +388,9 @@ const validateDiscardFunction = (
     radio.emit(
       "logMessage",
       red(
-        `\nError: Return type must be boolean for discard function "${discardFunctionName}" in contract "${
-          contractId.split(".")[1]
-        }".\n`
+        `\nError: Return type must be boolean for discard function "${discardFunctionName}" in contract "${getContractNameFromContractId(
+          contractId
+        )}".\n`
       )
     );
     return false;

--- a/property.ts
+++ b/property.ts
@@ -101,9 +101,11 @@ export const checkProperties = (
   );
 
   if (testFunctions?.length === 0) {
-    throw new Error(
-      `No test functions found for the "${sutContractName}" contract.`
+    radio.emit(
+      "logMessage",
+      red(`No test functions found for the "${sutContractName}" contract.\n`)
     );
+    return;
   }
 
   const eligibleTestFunctions = testFunctions.filter(
@@ -111,9 +113,13 @@ export const checkProperties = (
   );
 
   if (eligibleTestFunctions.length === 0) {
-    throw new Error(
-      `No eligible test functions found for the "${sutContractName}" contract. Note: trait references are not supported.`
+    radio.emit(
+      "logMessage",
+      red(
+        `No eligible test functions found for the "${sutContractName}" contract. Note: trait references are not supported.\n`
+      )
     );
+    return;
   }
 
   const radioReporter = (runDetails: any) => {
@@ -369,7 +375,7 @@ const validateDiscardFunction = (
 
   if (!isParamsMatch(testFunction, discardFunction)) {
     radio.emit(
-      "logFailure",
+      "logMessage",
       red(
         `\nError: Parameter mismatch for discard function "${discardFunctionName}" in contract "${
           contractId.split(".")[1]
@@ -381,7 +387,7 @@ const validateDiscardFunction = (
 
   if (!isReturnTypeBoolean(discardFunction)) {
     radio.emit(
-      "logFailure",
+      "logMessage",
       red(
         `\nError: Return type must be boolean for discard function "${discardFunctionName}" in contract "${
           contractId.split(".")[1]

--- a/shared.tests.ts
+++ b/shared.tests.ts
@@ -5,6 +5,7 @@ import {
   getSimnetDeployerContractsInterfaces,
   isTraitReferenceFunction,
   hexaString,
+  getContractNameFromContractId,
 } from "./shared";
 import { resolve } from "path";
 import fc from "fast-check";
@@ -212,5 +213,29 @@ describe("Fast-check deprecated generators replacement validation", () => {
     // Assert
     // Strict, same-order comparison.
     expect(JSON.stringify(a)).toEqual(JSON.stringify(b));
+  });
+});
+
+describe("Contract identifier parsing", () => {
+  it("gets correct contract name from contract identifier", () => {
+    const addressCharset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    const contractNameCharset =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    fc.assert(
+      // Arrange
+      fc.property(
+        fc.string({ unit: fc.constantFrom(...addressCharset) }),
+        fc.string({ unit: fc.constantFrom(...contractNameCharset) }),
+        (address, contractName) => {
+          const contractId = `${address}.${contractName}`;
+
+          // Act
+          const actual = getContractNameFromContractId(contractId);
+
+          // Assert
+          expect(actual).toBe(contractName);
+        }
+      )
+    );
   });
 });

--- a/shared.tests.ts
+++ b/shared.tests.ts
@@ -3,10 +3,12 @@ import {
   getFunctionsFromContractInterfaces,
   getFunctionsListForContract,
   getSimnetDeployerContractsInterfaces,
+  isTraitReferenceFunction,
   hexaString,
 } from "./shared";
 import { resolve } from "path";
 import fc from "fast-check";
+import { ContractInterfaceFunction } from "@hirosystems/clarinet-sdk-wasm";
 
 describe("Simnet contracts operations", () => {
   it("retrieves the contracts from the simnet", async () => {
@@ -71,6 +73,100 @@ describe("Simnet contracts operations", () => {
 
     // Assert
     expect(actualAllFunctionsMap).toEqual(expectedAllFunctionsMap);
+  });
+
+  it("trait reference finder returns false for a function witout traits", async () => {
+    // Arrange
+    const noTraitContractInterfaceFunction = {
+      name: "create-new-shipment",
+      access: "public",
+      args: [
+        {
+          name: "starting-location",
+          type: {
+            "string-ascii": {
+              length: 25,
+            },
+          },
+        },
+        {
+          name: "receiver",
+          type: "principal",
+        },
+      ],
+      outputs: {
+        type: {
+          response: {
+            ok: {
+              "string-ascii": {
+                length: 29,
+              },
+            },
+            error: "none",
+          },
+        },
+      },
+    } as ContractInterfaceFunction;
+
+    // Act
+    const hasTrait = isTraitReferenceFunction(noTraitContractInterfaceFunction);
+
+    // Assert
+    expect(hasTrait).toBe(false);
+  });
+
+  it("trait reference finder returns true for a function with traits", async () => {
+    // Arrange
+    const traitContractInterfaceFunction = {
+      name: "transfer-two",
+      access: "public",
+      args: [
+        {
+          name: "ft-contract",
+          type: {
+            tuple: [
+              {
+                name: "token",
+                type: "trait_reference",
+              },
+            ],
+          },
+        },
+        {
+          name: "nft-contract",
+          type: {
+            tuple: [
+              {
+                name: "token",
+                type: "trait_reference",
+              },
+            ],
+          },
+        },
+        {
+          name: "amount",
+          type: "uint128",
+        },
+        {
+          name: "recipient",
+          type: "principal",
+        },
+      ],
+      outputs: {
+        type: {
+          response: {
+            ok: "bool",
+            error: "uint128",
+          },
+        },
+      },
+    } as ContractInterfaceFunction;
+
+    // Act
+    const hasTrait = isTraitReferenceFunction(traitContractInterfaceFunction);
+
+    // Assert
+    expect(hasTrait).toBe(true);
   });
 });
 

--- a/shared.tests.ts
+++ b/shared.tests.ts
@@ -75,82 +75,74 @@ describe("Simnet contracts operations", () => {
     // Assert
     expect(actualAllFunctionsMap).toEqual(expectedAllFunctionsMap);
   });
+});
 
-  it("trait reference finder returns false for a function witout traits", async () => {
+describe("Trait reference detection", () => {
+  it("returns false when no arguments contain a trait reference", async () => {
     // Arrange
-    const noTraitContractInterfaceFunction = {
-      name: "create-new-shipment",
+    const noTraitFunction = {
+      name: "function-without-traits",
       access: "public",
       args: [
-        {
-          name: "starting-location",
-          type: {
-            "string-ascii": {
-              length: 25,
-            },
-          },
-        },
-        {
-          name: "receiver",
-          type: "principal",
-        },
+        { name: "arg1", type: "uint128" },
+        { name: "arg2", type: { buffer: { length: 10 } } },
+        { name: "arg3", type: { "string-ascii": { length: 20 } } },
+        { name: "arg4", type: "principal" },
+        { name: "arg5", type: "bool" },
+        { name: "arg6", type: "int128" },
       ],
       outputs: {
         type: {
           response: {
-            ok: {
-              "string-ascii": {
-                length: 29,
-              },
-            },
-            error: "none",
+            ok: "bool",
+            error: "uint128",
           },
         },
       },
     } as ContractInterfaceFunction;
 
     // Act
-    const hasTrait = isTraitReferenceFunction(noTraitContractInterfaceFunction);
+    const result = isTraitReferenceFunction(noTraitFunction);
 
     // Assert
-    expect(hasTrait).toBe(false);
+    expect(result).toBe(false);
   });
 
-  it("trait reference finder returns true for a function with traits", async () => {
+  it("returns true when an argument contains a trait reference", async () => {
     // Arrange
-    const traitContractInterfaceFunction = {
-      name: "transfer-two",
+    const traitFunction = {
+      name: "function-with-traits",
+      access: "public",
+      args: [
+        { name: "arg1", type: "trait_reference" },
+        { name: "arg2", type: "uint128" },
+      ],
+      outputs: {
+        type: {
+          response: {
+            ok: "bool",
+            error: "uint128",
+          },
+        },
+      },
+    } as ContractInterfaceFunction;
+
+    // Act
+    const result = isTraitReferenceFunction(traitFunction);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns false for a list argument without traits", async () => {
+    // Arrange
+    const listFunction = {
+      name: "list-without-traits",
       access: "public",
       args: [
         {
-          name: "ft-contract",
-          type: {
-            tuple: [
-              {
-                name: "token",
-                type: "trait_reference",
-              },
-            ],
-          },
-        },
-        {
-          name: "nft-contract",
-          type: {
-            tuple: [
-              {
-                name: "token",
-                type: "trait_reference",
-              },
-            ],
-          },
-        },
-        {
-          name: "amount",
-          type: "uint128",
-        },
-        {
-          name: "recipient",
-          type: "principal",
+          name: "listArg",
+          type: { list: { type: "uint128", length: 5 } },
         },
       ],
       outputs: {
@@ -164,10 +156,249 @@ describe("Simnet contracts operations", () => {
     } as ContractInterfaceFunction;
 
     // Act
-    const hasTrait = isTraitReferenceFunction(traitContractInterfaceFunction);
+    const result = isTraitReferenceFunction(listFunction);
 
     // Assert
-    expect(hasTrait).toBe(true);
+    expect(result).toBe(false);
+  });
+
+  it("returns true for a list argument with traits", async () => {
+    // Arrange
+    const listWithTraitFunction = {
+      name: "list-with-traits",
+      access: "public",
+      args: [
+        {
+          name: "listArg",
+          type: { list: { type: "trait_reference", length: 5 } },
+        },
+      ],
+      outputs: {
+        type: {
+          response: {
+            ok: "bool",
+            error: "uint128",
+          },
+        },
+      },
+    } as ContractInterfaceFunction;
+
+    // Act
+    const result = isTraitReferenceFunction(listWithTraitFunction);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns false for a tuple argument without traits", async () => {
+    // Arrange
+    const tupleFunction = {
+      name: "tuple-without-traits",
+      access: "public",
+      args: [
+        {
+          name: "tupleArg",
+          type: {
+            tuple: [
+              { name: "field1", type: "uint128" },
+              { name: "field2", type: { buffer: { length: 10 } } },
+            ],
+          },
+        },
+      ],
+      outputs: {
+        type: {
+          response: {
+            ok: "bool",
+            error: "uint128",
+          },
+        },
+      },
+    } as ContractInterfaceFunction;
+
+    // Act
+    const result = isTraitReferenceFunction(tupleFunction);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("returns true for a tuple argument with traits", async () => {
+    // Arrange
+    const tupleWithTraitFunction = {
+      name: "tuple-with-traits",
+      access: "public",
+      args: [
+        {
+          name: "tupleArg",
+          type: {
+            tuple: [
+              { name: "field1", type: "uint128" },
+              { name: "field2", type: "trait_reference" },
+            ],
+          },
+        },
+      ],
+      outputs: {
+        type: {
+          response: {
+            ok: "bool",
+            error: "uint128",
+          },
+        },
+      },
+    } as ContractInterfaceFunction;
+
+    // Act
+    const result = isTraitReferenceFunction(tupleWithTraitFunction);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns false for an optional argument without traits", async () => {
+    // Arrange
+    const optionalFunction = {
+      name: "optional-without-traits",
+      access: "public",
+      args: [{ name: "optionalArg", type: { optional: "uint128" } }],
+      outputs: {
+        type: {
+          response: {
+            ok: "bool",
+            error: "uint128",
+          },
+        },
+      },
+    } as ContractInterfaceFunction;
+
+    // Act
+    const result = isTraitReferenceFunction(optionalFunction);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("returns true for an optional argument with traits", async () => {
+    // Arrange
+    const optionalWithTraitFunction = {
+      name: "optional-with-traits",
+      access: "public",
+      args: [{ name: "optionalArg", type: { optional: "trait_reference" } }],
+      outputs: {
+        type: {
+          response: {
+            ok: "bool",
+            error: "uint128",
+          },
+        },
+      },
+    } as ContractInterfaceFunction;
+
+    // Act
+    const result = isTraitReferenceFunction(optionalWithTraitFunction);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns false for a response argument without traits", async () => {
+    // Arrange
+    const responseFunction = {
+      name: "response-without-traits",
+      access: "public",
+      args: [
+        {
+          name: "responseArg",
+          type: {
+            response: { ok: "uint128", error: "bool" },
+          },
+        },
+      ],
+      outputs: {
+        type: {
+          response: {
+            ok: "bool",
+            error: "uint128",
+          },
+        },
+      },
+    } as ContractInterfaceFunction;
+
+    // Act
+    const result = isTraitReferenceFunction(responseFunction);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("returns true for a response argument with traits", async () => {
+    // Arrange
+    const responseWithTraitFunction = {
+      name: "response-with-traits",
+      access: "public",
+      args: [
+        {
+          name: "responseArg",
+          type: {
+            response: { ok: "trait_reference", error: "uint128" },
+          },
+        },
+      ],
+      outputs: {
+        type: {
+          response: {
+            ok: "bool",
+            error: "uint128",
+          },
+        },
+      },
+    } as ContractInterfaceFunction;
+
+    // Act
+    const result = isTraitReferenceFunction(responseWithTraitFunction);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns false for unexpected argument types", async () => {
+    // Arrange
+    const unexpectedTypeFunction = {
+      name: "unexpected-type-function",
+      access: "public",
+      args: [{ name: "unexpectedArg", type: "custom_type" as any }],
+      outputs: {
+        type: {
+          response: {
+            ok: "bool",
+            error: "uint128",
+          },
+        },
+      },
+    } as ContractInterfaceFunction;
+
+    // Act
+    const result = isTraitReferenceFunction(unexpectedTypeFunction);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("returns false for an argument with an unrecognized complex type", async () => {
+    // Arrange
+    const unrecognizedTypeFunction = {
+      name: "unrecognized-type-function",
+      access: "public",
+      args: [{ name: "unknownArg", type: { unknown: "some_value" } as any }],
+      outputs: { type: "bool" },
+    } as ContractInterfaceFunction;
+
+    // Act
+    const result = isTraitReferenceFunction(unrecognizedTypeFunction);
+
+    // Assert
+    expect(result).toBe(false);
   });
 });
 

--- a/shared.ts
+++ b/shared.ts
@@ -342,3 +342,6 @@ export const isTraitReferenceFunction = (
 
   return fn.args.some((arg) => hasTraitReference(arg.type as ParameterType));
 };
+
+export const getContractNameFromContractId = (contractId: string): string =>
+  contractId.split(".")[1];

--- a/shared.ts
+++ b/shared.ts
@@ -59,8 +59,8 @@ export const getFunctionsListForContract = (
 ): ContractInterfaceFunction[] => functionsMap.get(contractId) || [];
 
 /** For a given function, dynamically generate fast-check arbitraries.
- * @param fn ContractInterfaceFunction
- * @returns Array of fast-check arbitraries
+ * @param fn The function interface.
+ * @returns Array of fast-check arbitraries.
  */
 export const functionToArbitrary = (
   fn: ContractInterfaceFunction,
@@ -72,15 +72,15 @@ export const functionToArbitrary = (
 
 /**
  * For a given type, generate a fast-check arbitrary.
- * @param type
- * @returns fast-check arbitrary
+ * @param type The parameter type.
+ * @returns Fast-check arbitrary.
  */
 const parameterTypeToArbitrary = (
   type: ParameterType,
   addresses: string[]
 ): fc.Arbitrary<any> => {
   if (typeof type === "string") {
-    // The type is a base type
+    // The type is a base type.
     if (type === "principal") {
       if (addresses.length === 0)
         throw new Error(
@@ -91,7 +91,7 @@ const parameterTypeToArbitrary = (
       throw new Error("Unsupported parameter type: trait_reference");
     } else return baseTypesToArbitrary[type];
   } else {
-    // The type is a complex type
+    // The type is a complex type.
     if ("buffer" in type) {
       return complexTypesToArbitrary["buffer"](type.buffer.length);
     } else if ("string-ascii" in type) {
@@ -212,13 +212,12 @@ const charSet =
 
 /**
  * Convert function arguments to Clarity values.
- * @param fn ContractFunction.
+ * @param fn The function interface.
  * @param args Array of arguments.
  * @returns Array of Clarity values.
  */
-export const argsToCV = (fn: ContractInterfaceFunction, args: any[]) => {
-  return fn.args.map((arg, i) => argToCV(args[i], arg.type as ParameterType));
-};
+export const argsToCV = (fn: ContractInterfaceFunction, args: any[]) =>
+  fn.args.map((arg, i) => argToCV(args[i], arg.type as ParameterType));
 
 /**
  * Convert a function argument to a Clarity value.
@@ -312,7 +311,7 @@ const isBaseType = (type: ParameterType): type is BaseType => {
 /**
  * Checks if any parameter of the function contains a `trait_reference` type.
  * @param fn The function interface.
- * @returns boolean - true if the function contains a trait reference, false
+ * @returns Boolean - true if the function contains a trait reference, false
  * otherwise.
  */
 export const isTraitReferenceFunction = (

--- a/shared.types.ts
+++ b/shared.types.ts
@@ -45,7 +45,12 @@ export type ComplexTypesToCV = {
 
 // Types used for argument generation.
 
-export type BaseType = "int128" | "uint128" | "bool" | "principal";
+export type BaseType =
+  | "int128"
+  | "uint128"
+  | "bool"
+  | "principal"
+  | "trait_reference";
 
 type ComplexType =
   | { buffer: { length: number } }
@@ -63,6 +68,8 @@ export type BaseTypesToArbitrary = {
   uint128: ReturnType<typeof fc.nat>;
   bool: ReturnType<typeof fc.boolean>;
   principal: (addresses: string[]) => ReturnType<typeof fc.constantFrom>;
+  // Trait reference is not yet supported. This is a placeholder.
+  trait_reference: undefined;
 };
 
 export type ComplexTypesToArbitrary = {


### PR DESCRIPTION
This PR updates `rv` by gracefully handling `trait references`. It skips functions with `trait reference` parameters from being selected for argument generation and random execution, which previously caused crashes. Currently, `trait references` are not supported, but this feature is planned (see #65).

Additionally, this PR follows [The Boy Scout Rule](https://www.oreilly.com/library/view/97-things-every/9780596809515/ch08.html), leaving the codebase cleaner than it was found. _Apparently_ unrelated updates such as refined arbitrary definitions, refactored comments, and updated logging can be found in this PR.