### PR TITLE
Bump version to `0.1.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rendezvous",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rendezvous",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "license": "GPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rendezvous",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Meet your contract's vulnerabilities head-on.",
   "main": "app.js",
   "bin": {


### PR DESCRIPTION
This version includes a fix that skips functions with `trait reference` parameters from being selected for argument generation and random execution, which previously caused crashes.