### PR TITLE
Bump version to 0.1.2 for NPM release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stacks/rendezvous",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stacks/rendezvous",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "license": "GPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/rendezvous",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Meet your contract's vulnerabilities head-on.",
   "main": "app.js",
   "bin": {


### PR DESCRIPTION
Updated the version in package.json for publishing.

Prior commits (https://github.com/stacks-network/rendezvous/compare/0.1.1...a992f516277ae4d71d22123134145c7d88ac710c) added the "files" field and other changes since the 0.1.1 tag.