### PR TITLE
Automate NPM publishing on GitHub release

### DIFF
--- a/.github/workflows/npm-publish-release.yml
+++ b/.github/workflows/npm-publish-release.yml
@@ -13,6 +13,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - run: npm test
+      - run: npm run build
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish-release.yml
+++ b/.github/workflows/npm-publish-release.yml
@@ -1,0 +1,18 @@
+name: npm-publish
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm test
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@stacks/rendezvous",
       "version": "0.1.2",
-      "hasInstallScript": true,
       "license": "GPL-3.0-only",
       "dependencies": {
         "@hirosystems/clarinet-sdk": "2.12.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "rv": "./dist/app.js"
   },
   "scripts": {
-    "postinstall": "npx -p typescript tsc --project tsconfig.json && node -e \"if (process.platform !== 'win32') require('fs').chmodSync('./dist/app.js', 0o755);\"",
+    "build": "npx -p typescript tsc --project tsconfig.json && node -e \"if (process.platform !== 'win32') require('fs').chmodSync('./dist/app.js', 0o755);\"",
     "test": "npx tsc --project tsconfig.json && npx jest",
     "test:coverage": "npx tsc --project tsconfig.json && npx jest --coverage"
   },


### PR DESCRIPTION
This PR automates NPM publishing on GitHub releases, adding a workflow for published release events. Resolves #89.