### PR TITLE
Add repository URL to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "README.md",
     "LICENSE"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stacks-network/rendezvous.git"
+  },
   "dependencies": {
     "@hirosystems/clarinet-sdk": "2.12.0",
     "@stacks/transactions": "^6.16.1",


### PR DESCRIPTION
This PR updates `package.json` by adding the repository URL, linking the npm package page to the GitHub repository.