### PR TITLE
Enable calling multiple `SUT` functions per invariant testing run

### DIFF
--- a/heatstroke.tests.ts
+++ b/heatstroke.tests.ts
@@ -17,21 +17,21 @@ describe("Custom reporter logging", () => {
           numRuns: fc.nat(),
           seed: fc.nat(),
           contractName: fc.ascii(),
-          selectedFunction: fc.record({
-            name: fc.ascii(),
-            access: fc.ascii(),
-            outputs: fc.array(fc.ascii()),
-          }),
-          functionArgsArb: fc.array(
-            fc.oneof(fc.ascii(), fc.nat(), fc.boolean())
+          selectedFunctions: fc.array(
+            fc.record({
+              name: fc.ascii(),
+              access: fc.ascii(),
+              outputs: fc.array(fc.ascii()),
+            })
+          ),
+          selectedFunctionsArgsList: fc.tuple(
+            fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean()))
           ),
           selectedInvariant: fc.record({
             name: fc.ascii(),
             access: fc.ascii(),
           }),
-          invariantArgsArb: fc.array(
-            fc.oneof(fc.ascii(), fc.nat(), fc.boolean())
-          ),
+          invariantArgs: fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean())),
           errorMessage: fc.ascii(),
           sutCaller: fc.constantFrom(
             ...new Map(
@@ -49,17 +49,17 @@ describe("Custom reporter logging", () => {
           numRuns: number;
           seed: number;
           contractName: string;
-          selectedFunction: {
+          selectedFunctions: {
             name: string;
             access: string;
             outputs: string[];
-          };
-          functionArgsArb: (string | number | boolean)[];
+          }[];
+          selectedFunctionsArgsList: (string | number | boolean)[][];
           selectedInvariant: {
             name: string;
             access: string;
           };
-          invariantArgsArb: (string | number | boolean)[];
+          invariantArgs: (string | number | boolean)[];
           errorMessage: string;
           sutCaller: [string, string];
           invariantCaller: [string, string];
@@ -79,17 +79,13 @@ describe("Custom reporter logging", () => {
             counterexample: [
               {
                 rendezvousContractId: rendezvousContractId,
-                selectedFunction: {
-                  name: r.selectedFunction.name,
-                  access: r.selectedFunction.access,
-                  outputs: r.selectedFunction.outputs,
-                },
-                functionArgsArb: r.functionArgsArb,
+                selectedFunctions: r.selectedFunctions,
+                selectedFunctionsArgsList: r.selectedFunctionsArgsList,
                 selectedInvariant: {
                   name: r.selectedInvariant.name,
                   access: r.selectedInvariant.access,
                 },
-                invariantArgsArb: r.invariantArgsArb,
+                invariantArgs: r.invariantArgs,
                 sutCaller: r.sutCaller,
                 invariantCaller: r.invariantCaller,
               },
@@ -108,12 +104,24 @@ describe("Custom reporter logging", () => {
             `- Contract : ${getContractNameFromContractId(
               rendezvousContractId
             )}`,
-            `- Function : ${r.selectedFunction.name} (${r.selectedFunction.access})`,
-            `- Arguments: ${JSON.stringify(r.functionArgsArb)}`,
+            `- Functions: ${r.selectedFunctions
+              .map((selectedFunction) => selectedFunction.name)
+              .join(", ")} (${r.selectedFunctions
+              .map((selectedFunction) => selectedFunction.access)
+              .join(", ")})`,
+            `- Arguments: ${r.selectedFunctionsArgsList
+              .map((selectedFunctionArgs) =>
+                JSON.stringify(selectedFunctionArgs)
+              )
+              .join(", ")}`,
             `- Caller   : ${r.sutCaller[0]}`,
-            `- Outputs  : ${JSON.stringify(r.selectedFunction.outputs)}`,
+            `- Outputs  : ${r.selectedFunctions
+              .map((selectedFunction) =>
+                JSON.stringify(selectedFunction.outputs)
+              )
+              .join(", ")}`,
             `- Invariant: ${r.selectedInvariant.name} (${r.selectedInvariant.access})`,
-            `- Arguments: ${JSON.stringify(r.invariantArgsArb)}`,
+            `- Arguments: ${JSON.stringify(r.invariantArgs)}`,
             `- Caller   : ${r.invariantCaller[0]}`,
             `\nWhat happened? Rendezvous went on a rampage and found a weak spot:\n`,
             `The invariant "${
@@ -144,21 +152,21 @@ describe("Custom reporter logging", () => {
           numRuns: fc.nat(),
           seed: fc.nat(),
           contractName: fc.ascii(),
-          selectedFunction: fc.record({
-            name: fc.ascii(),
-            access: fc.ascii(),
-            outputs: fc.array(fc.ascii()),
-          }),
-          functionArgsArb: fc.array(
-            fc.oneof(fc.ascii(), fc.nat(), fc.boolean())
+          selectedFunctions: fc.array(
+            fc.record({
+              name: fc.ascii(),
+              access: fc.ascii(),
+              outputs: fc.array(fc.ascii()),
+            })
+          ),
+          selectedFunctionsArgsList: fc.tuple(
+            fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean()))
           ),
           selectedInvariant: fc.record({
             name: fc.ascii(),
             access: fc.ascii(),
           }),
-          invariantArgsArb: fc.array(
-            fc.oneof(fc.ascii(), fc.nat(), fc.boolean())
-          ),
+          invariantArgs: fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean())),
           errorMessage: fc.ascii(),
           sutCaller: fc.constantFrom(
             ...new Map(
@@ -177,17 +185,17 @@ describe("Custom reporter logging", () => {
           numRuns: number;
           seed: number;
           contractName: string;
-          selectedFunction: {
+          selectedFunctions: {
             name: string;
             access: string;
             outputs: string[];
-          };
-          functionArgsArb: (string | number | boolean)[];
+          }[];
+          selectedFunctionsArgsList: (string | number | boolean)[][];
           selectedInvariant: {
             name: string;
             access: string;
           };
-          invariantArgsArb: (string | number | boolean)[];
+          invariantArgs: (string | number | boolean)[];
           errorMessage: string;
           sutCaller: [string, string];
           invariantCaller: [string, string];
@@ -208,17 +216,13 @@ describe("Custom reporter logging", () => {
             counterexample: [
               {
                 rendezvousContractId: rendezvousContractId,
-                selectedFunction: {
-                  name: r.selectedFunction.name,
-                  access: r.selectedFunction.access,
-                  outputs: r.selectedFunction.outputs,
-                },
-                functionArgsArb: r.functionArgsArb,
+                selectedFunctions: r.selectedFunctions,
+                selectedFunctionsArgsList: r.selectedFunctionsArgsList,
                 selectedInvariant: {
                   name: r.selectedInvariant.name,
                   access: r.selectedInvariant.access,
                 },
-                invariantArgsArb: r.invariantArgsArb,
+                invariantArgs: r.invariantArgs,
                 sutCaller: r.sutCaller,
                 invariantCaller: r.invariantCaller,
               },
@@ -238,12 +242,24 @@ describe("Custom reporter logging", () => {
             `- Contract : ${getContractNameFromContractId(
               rendezvousContractId
             )}`,
-            `- Function : ${r.selectedFunction.name} (${r.selectedFunction.access})`,
-            `- Arguments: ${JSON.stringify(r.functionArgsArb)}`,
+            `- Functions: ${r.selectedFunctions
+              .map((selectedFunction) => selectedFunction.name)
+              .join(", ")} (${r.selectedFunctions
+              .map((selectedFunction) => selectedFunction.access)
+              .join(", ")})`,
+            `- Arguments: ${r.selectedFunctionsArgsList
+              .map((selectedFunctionArgs) =>
+                JSON.stringify(selectedFunctionArgs)
+              )
+              .join(", ")}`,
             `- Caller   : ${r.sutCaller[0]}`,
-            `- Outputs  : ${JSON.stringify(r.selectedFunction.outputs)}`,
+            `- Outputs  : ${r.selectedFunctions
+              .map((selectedFunction) =>
+                JSON.stringify(selectedFunction.outputs)
+              )
+              .join(", ")}`,
             `- Invariant: ${r.selectedInvariant.name} (${r.selectedInvariant.access})`,
-            `- Arguments: ${JSON.stringify(r.invariantArgsArb)}`,
+            `- Arguments: ${JSON.stringify(r.invariantArgs)}`,
             `- Caller   : ${r.invariantCaller[0]}`,
             `\nWhat happened? Rendezvous went on a rampage and found a weak spot:\n`,
             `The invariant "${
@@ -275,21 +291,21 @@ describe("Custom reporter logging", () => {
           numRuns: fc.nat(),
           seed: fc.nat(),
           contractName: fc.ascii(),
-          selectedFunction: fc.record({
-            name: fc.ascii(),
-            access: fc.ascii(),
-            outputs: fc.array(fc.ascii()),
-          }),
-          functionArgsArb: fc.array(
-            fc.oneof(fc.ascii(), fc.nat(), fc.boolean())
+          selectedFunctions: fc.array(
+            fc.record({
+              name: fc.ascii(),
+              access: fc.ascii(),
+              outputs: fc.array(fc.ascii()),
+            })
+          ),
+          selectedFunctionsArgsList: fc.tuple(
+            fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean()))
           ),
           selectedInvariant: fc.record({
             name: fc.ascii(),
             access: fc.ascii(),
           }),
-          invariantArgsArb: fc.array(
-            fc.oneof(fc.ascii(), fc.nat(), fc.boolean())
-          ),
+          invariantArgs: fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean())),
           errorMessage: fc.ascii(),
           sutCaller: fc.constantFrom(
             ...new Map(
@@ -308,17 +324,17 @@ describe("Custom reporter logging", () => {
           numRuns: number;
           seed: number;
           contractName: string;
-          selectedFunction: {
+          selectedFunctions: {
             name: string;
             access: string;
             outputs: string[];
-          };
-          functionArgsArb: (string | number | boolean)[];
+          }[];
+          selectedFunctionsArgsList: (string | number | boolean)[][];
           selectedInvariant: {
             name: string;
             access: string;
           };
-          invariantArgsArb: (string | number | boolean)[];
+          invariantArgs: (string | number | boolean)[];
           errorMessage: string;
           sutCaller: [string, string];
           invariantCaller: [string, string];
@@ -339,17 +355,13 @@ describe("Custom reporter logging", () => {
             counterexample: [
               {
                 rendezvousContractId: rendezvousContractId,
-                selectedFunction: {
-                  name: r.selectedFunction.name,
-                  access: r.selectedFunction.access,
-                  outputs: r.selectedFunction.outputs,
-                },
-                functionArgsArb: r.functionArgsArb,
+                selectedFunction: r.selectedFunctions,
+                functionArgsArb: r.selectedFunctionsArgsList,
                 selectedInvariant: {
                   name: r.selectedInvariant.name,
                   access: r.selectedInvariant.access,
                 },
-                invariantArgsArb: r.invariantArgsArb,
+                invariantArgs: r.invariantArgs,
                 sutCaller: r.sutCaller,
                 invariantCaller: r.invariantCaller,
               },

--- a/heatstroke.tests.ts
+++ b/heatstroke.tests.ts
@@ -1,8 +1,9 @@
-import fc from "fast-check";
-import { reporter } from "./heatstroke";
 import { EventEmitter } from "events";
 import { resolve } from "path";
 import { initSimnet } from "@hirosystems/clarinet-sdk";
+import { ContractInterfaceFunction } from "@hirosystems/clarinet-sdk-wasm";
+import fc from "fast-check";
+import { reporter } from "./heatstroke";
 import { getContractNameFromContractId } from "./shared";
 
 describe("Custom reporter logging", () => {
@@ -22,6 +23,7 @@ describe("Custom reporter logging", () => {
               name: fc.ascii(),
               access: fc.ascii(),
               outputs: fc.array(fc.ascii()),
+              args: fc.anything(),
             })
           ),
           selectedFunctionsArgsList: fc.tuple(
@@ -30,6 +32,8 @@ describe("Custom reporter logging", () => {
           selectedInvariant: fc.record({
             name: fc.ascii(),
             access: fc.ascii(),
+            outputs: fc.array(fc.ascii()),
+            args: fc.anything(),
           }),
           invariantArgs: fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean())),
           errorMessage: fc.ascii(),
@@ -55,11 +59,14 @@ describe("Custom reporter logging", () => {
             name: string;
             access: string;
             outputs: string[];
+            args: any;
           }[];
           selectedFunctionsArgsList: (string | number | boolean)[][];
           selectedInvariant: {
             name: string;
             access: string;
+            outputs: string[];
+            args: any;
           };
           invariantArgs: (string | number | boolean)[];
           errorMessage: string;
@@ -81,12 +88,11 @@ describe("Custom reporter logging", () => {
             counterexample: [
               {
                 rendezvousContractId: rendezvousContractId,
-                selectedFunctions: r.selectedFunctions,
+                selectedFunctions:
+                  r.selectedFunctions as any as ContractInterfaceFunction[],
                 selectedFunctionsArgsList: r.selectedFunctionsArgsList,
-                selectedInvariant: {
-                  name: r.selectedInvariant.name,
-                  access: r.selectedInvariant.access,
-                },
+                selectedInvariant:
+                  r.selectedInvariant as any as ContractInterfaceFunction,
                 invariantArgs: r.invariantArgs,
                 sutCallers: r.sutCallers,
                 invariantCaller: r.invariantCaller,
@@ -161,6 +167,7 @@ describe("Custom reporter logging", () => {
               name: fc.ascii(),
               access: fc.ascii(),
               outputs: fc.array(fc.ascii()),
+              args: fc.anything(),
             })
           ),
           selectedFunctionsArgsList: fc.tuple(
@@ -169,6 +176,8 @@ describe("Custom reporter logging", () => {
           selectedInvariant: fc.record({
             name: fc.ascii(),
             access: fc.ascii(),
+            outputs: fc.array(fc.ascii()),
+            args: fc.anything(),
           }),
           invariantArgs: fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean())),
           errorMessage: fc.ascii(),
@@ -195,11 +204,14 @@ describe("Custom reporter logging", () => {
             name: string;
             access: string;
             outputs: string[];
+            args: any;
           }[];
           selectedFunctionsArgsList: (string | number | boolean)[][];
           selectedInvariant: {
             name: string;
             access: string;
+            outputs: string[];
+            args: any;
           };
           invariantArgs: (string | number | boolean)[];
           errorMessage: string;
@@ -222,12 +234,11 @@ describe("Custom reporter logging", () => {
             counterexample: [
               {
                 rendezvousContractId: rendezvousContractId,
-                selectedFunctions: r.selectedFunctions,
+                selectedFunctions:
+                  r.selectedFunctions as any as ContractInterfaceFunction[],
                 selectedFunctionsArgsList: r.selectedFunctionsArgsList,
-                selectedInvariant: {
-                  name: r.selectedInvariant.name,
-                  access: r.selectedInvariant.access,
-                },
+                selectedInvariant:
+                  r.selectedInvariant as any as ContractInterfaceFunction,
                 invariantArgs: r.invariantArgs,
                 sutCallers: r.sutCallers,
                 invariantCaller: r.invariantCaller,
@@ -304,6 +315,7 @@ describe("Custom reporter logging", () => {
               name: fc.ascii(),
               access: fc.ascii(),
               outputs: fc.array(fc.ascii()),
+              args: fc.anything(),
             })
           ),
           selectedFunctionsArgsList: fc.tuple(
@@ -312,6 +324,8 @@ describe("Custom reporter logging", () => {
           selectedInvariant: fc.record({
             name: fc.ascii(),
             access: fc.ascii(),
+            outputs: fc.array(fc.ascii()),
+            args: fc.anything(),
           }),
           invariantArgs: fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean())),
           errorMessage: fc.ascii(),
@@ -338,11 +352,14 @@ describe("Custom reporter logging", () => {
             name: string;
             access: string;
             outputs: string[];
+            args: any;
           }[];
           selectedFunctionsArgsList: (string | number | boolean)[][];
           selectedInvariant: {
             name: string;
             access: string;
+            args: any;
+            outputs: string[];
           };
           invariantArgs: (string | number | boolean)[];
           errorMessage: string;
@@ -365,12 +382,11 @@ describe("Custom reporter logging", () => {
             counterexample: [
               {
                 rendezvousContractId: rendezvousContractId,
-                selectedFunction: r.selectedFunctions,
-                functionArgsArb: r.selectedFunctionsArgsList,
-                selectedInvariant: {
-                  name: r.selectedInvariant.name,
-                  access: r.selectedInvariant.access,
-                },
+                selectedFunctions:
+                  r.selectedFunctions as any as ContractInterfaceFunction[],
+                selectedFunctionsArgsList: r.selectedFunctionsArgsList,
+                selectedInvariant:
+                  r.selectedInvariant as any as ContractInterfaceFunction,
                 invariantArgs: r.invariantArgs,
                 sutCallers: r.sutCallers,
                 invariantCaller: r.invariantCaller,
@@ -406,6 +422,7 @@ describe("Custom reporter logging", () => {
             name: fc.ascii(),
             access: fc.ascii(),
             outputs: fc.array(fc.ascii()),
+            args: fc.anything(),
           }),
           functionArgsArb: fc.array(
             fc.oneof(fc.ascii(), fc.nat(), fc.boolean())
@@ -426,6 +443,7 @@ describe("Custom reporter logging", () => {
             name: string;
             access: string;
             outputs: string[];
+            args: any;
           };
           functionArgsArb: (string | number | boolean)[];
           errorMessage: string;
@@ -446,11 +464,8 @@ describe("Custom reporter logging", () => {
             counterexample: [
               {
                 testContractId: testContractId,
-                selectedTestFunction: {
-                  name: r.selectedTestFunction.name,
-                  access: r.selectedTestFunction.access,
-                  outputs: r.selectedTestFunction.outputs,
-                },
+                selectedTestFunction:
+                  r.selectedTestFunction as any as ContractInterfaceFunction,
                 functionArgsArb: r.functionArgsArb,
                 testCaller: r.testCaller,
               },
@@ -508,6 +523,7 @@ describe("Custom reporter logging", () => {
             name: fc.ascii(),
             access: fc.ascii(),
             outputs: fc.array(fc.ascii()),
+            args: fc.anything(),
           }),
           functionArgsArb: fc.array(
             fc.oneof(fc.ascii(), fc.nat(), fc.boolean())
@@ -529,6 +545,7 @@ describe("Custom reporter logging", () => {
             name: string;
             access: string;
             outputs: string[];
+            args: any;
           };
           functionArgsArb: (string | number | boolean)[];
           errorMessage: string;
@@ -550,11 +567,8 @@ describe("Custom reporter logging", () => {
             counterexample: [
               {
                 testContractId: testContractId,
-                selectedTestFunction: {
-                  name: r.selectedTestFunction.name,
-                  access: r.selectedTestFunction.access,
-                  outputs: r.selectedTestFunction.outputs,
-                },
+                selectedTestFunction:
+                  r.selectedTestFunction as any as ContractInterfaceFunction,
                 functionArgsArb: r.functionArgsArb,
                 testCaller: r.testCaller,
               },
@@ -612,6 +626,7 @@ describe("Custom reporter logging", () => {
             name: fc.ascii(),
             access: fc.ascii(),
             outputs: fc.array(fc.ascii()),
+            args: fc.anything(),
           }),
           functionArgsArb: fc.array(
             fc.oneof(fc.ascii(), fc.nat(), fc.boolean())
@@ -632,6 +647,7 @@ describe("Custom reporter logging", () => {
             name: string;
             access: string;
             outputs: string[];
+            args: any;
           };
           functionArgsArb: (string | number | boolean)[];
           errorMessage: string;
@@ -652,11 +668,8 @@ describe("Custom reporter logging", () => {
             counterexample: [
               {
                 testContractId: testContractId,
-                selectedTestFunction: {
-                  name: r.selectedTestFunction.name,
-                  access: r.selectedTestFunction.access,
-                  outputs: r.selectedTestFunction.outputs,
-                },
+                selectedTestFunction:
+                  r.selectedTestFunction as any as ContractInterfaceFunction,
                 functionArgsArb: r.functionArgsArb,
                 testCaller: r.testCaller,
               },

--- a/heatstroke.tests.ts
+++ b/heatstroke.tests.ts
@@ -33,10 +33,12 @@ describe("Custom reporter logging", () => {
           }),
           invariantArgs: fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean())),
           errorMessage: fc.ascii(),
-          sutCaller: fc.constantFrom(
-            ...new Map(
-              [...simnet.getAccounts()].filter(([key]) => key !== "faucet")
-            ).entries()
+          sutCallers: fc.array(
+            fc.constantFrom(
+              ...new Map(
+                [...simnet.getAccounts()].filter(([key]) => key !== "faucet")
+              ).entries()
+            )
           ),
           invariantCaller: fc.constantFrom(
             ...new Map(
@@ -61,7 +63,7 @@ describe("Custom reporter logging", () => {
           };
           invariantArgs: (string | number | boolean)[];
           errorMessage: string;
-          sutCaller: [string, string];
+          sutCallers: [string, string][];
           invariantCaller: [string, string];
         }) => {
           const emittedErrorLogs: string[] = [];
@@ -86,7 +88,7 @@ describe("Custom reporter logging", () => {
                   access: r.selectedInvariant.access,
                 },
                 invariantArgs: r.invariantArgs,
-                sutCaller: r.sutCaller,
+                sutCallers: r.sutCallers,
                 invariantCaller: r.invariantCaller,
               },
             ],
@@ -114,7 +116,9 @@ describe("Custom reporter logging", () => {
                 JSON.stringify(selectedFunctionArgs)
               )
               .join(", ")}`,
-            `- Caller   : ${r.sutCaller[0]}`,
+            `- Callers  : ${r.sutCallers
+              .map((sutCaller) => sutCaller[0])
+              .join(", ")}`,
             `- Outputs  : ${r.selectedFunctions
               .map((selectedFunction) =>
                 JSON.stringify(selectedFunction.outputs)
@@ -168,10 +172,12 @@ describe("Custom reporter logging", () => {
           }),
           invariantArgs: fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean())),
           errorMessage: fc.ascii(),
-          sutCaller: fc.constantFrom(
-            ...new Map(
-              [...simnet.getAccounts()].filter(([key]) => key !== "faucet")
-            ).entries()
+          sutCallers: fc.array(
+            fc.constantFrom(
+              ...new Map(
+                [...simnet.getAccounts()].filter(([key]) => key !== "faucet")
+              ).entries()
+            )
           ),
           invariantCaller: fc.constantFrom(
             ...new Map(
@@ -197,7 +203,7 @@ describe("Custom reporter logging", () => {
           };
           invariantArgs: (string | number | boolean)[];
           errorMessage: string;
-          sutCaller: [string, string];
+          sutCallers: [string, string][];
           invariantCaller: [string, string];
         }) => {
           const emittedErrorLogs: string[] = [];
@@ -223,7 +229,7 @@ describe("Custom reporter logging", () => {
                   access: r.selectedInvariant.access,
                 },
                 invariantArgs: r.invariantArgs,
-                sutCaller: r.sutCaller,
+                sutCallers: r.sutCallers,
                 invariantCaller: r.invariantCaller,
               },
             ],
@@ -252,7 +258,9 @@ describe("Custom reporter logging", () => {
                 JSON.stringify(selectedFunctionArgs)
               )
               .join(", ")}`,
-            `- Caller   : ${r.sutCaller[0]}`,
+            `- Callers  : ${r.sutCallers
+              .map((sutCaller) => sutCaller[0])
+              .join(", ")}`,
             `- Outputs  : ${r.selectedFunctions
               .map((selectedFunction) =>
                 JSON.stringify(selectedFunction.outputs)
@@ -307,10 +315,12 @@ describe("Custom reporter logging", () => {
           }),
           invariantArgs: fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean())),
           errorMessage: fc.ascii(),
-          sutCaller: fc.constantFrom(
-            ...new Map(
-              [...simnet.getAccounts()].filter(([key]) => key !== "faucet")
-            ).entries()
+          sutCallers: fc.array(
+            fc.constantFrom(
+              ...new Map(
+                [...simnet.getAccounts()].filter(([key]) => key !== "faucet")
+              ).entries()
+            )
           ),
           invariantCaller: fc.constantFrom(
             ...new Map(
@@ -336,7 +346,7 @@ describe("Custom reporter logging", () => {
           };
           invariantArgs: (string | number | boolean)[];
           errorMessage: string;
-          sutCaller: [string, string];
+          sutCallers: [string, string][];
           invariantCaller: [string, string];
         }) => {
           const emittedErrorLogs: string[] = [];
@@ -362,7 +372,7 @@ describe("Custom reporter logging", () => {
                   access: r.selectedInvariant.access,
                 },
                 invariantArgs: r.invariantArgs,
-                sutCaller: r.sutCaller,
+                sutCallers: r.sutCallers,
                 invariantCaller: r.invariantCaller,
               },
             ],

--- a/heatstroke.tests.ts
+++ b/heatstroke.tests.ts
@@ -424,9 +424,7 @@ describe("Custom reporter logging", () => {
             outputs: fc.array(fc.ascii()),
             args: fc.anything(),
           }),
-          functionArgsArb: fc.array(
-            fc.oneof(fc.ascii(), fc.nat(), fc.boolean())
-          ),
+          functionArgs: fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean())),
           errorMessage: fc.ascii(),
           testCaller: fc.constantFrom(
             ...new Map(
@@ -445,7 +443,7 @@ describe("Custom reporter logging", () => {
             outputs: string[];
             args: any;
           };
-          functionArgsArb: (string | number | boolean)[];
+          functionArgs: (string | number | boolean)[];
           errorMessage: string;
           testCaller: [string, string];
         }) => {
@@ -466,7 +464,7 @@ describe("Custom reporter logging", () => {
                 testContractId: testContractId,
                 selectedTestFunction:
                   r.selectedTestFunction as any as ContractInterfaceFunction,
-                functionArgsArb: r.functionArgsArb,
+                functionArgs: r.functionArgs,
                 testCaller: r.testCaller,
               },
             ],
@@ -485,7 +483,7 @@ describe("Custom reporter logging", () => {
               testContractId
             )}`,
             `- Test Function : ${r.selectedTestFunction.name} (${r.selectedTestFunction.access})`,
-            `- Arguments     : ${JSON.stringify(r.functionArgsArb)}`,
+            `- Arguments     : ${JSON.stringify(r.functionArgs)}`,
             `- Caller        : ${r.testCaller[0]}`,
             `- Outputs       : ${JSON.stringify(
               r.selectedTestFunction.outputs
@@ -525,9 +523,7 @@ describe("Custom reporter logging", () => {
             outputs: fc.array(fc.ascii()),
             args: fc.anything(),
           }),
-          functionArgsArb: fc.array(
-            fc.oneof(fc.ascii(), fc.nat(), fc.boolean())
-          ),
+          functionArgs: fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean())),
           errorMessage: fc.ascii(),
           testCaller: fc.constantFrom(
             ...new Map(
@@ -547,7 +543,7 @@ describe("Custom reporter logging", () => {
             outputs: string[];
             args: any;
           };
-          functionArgsArb: (string | number | boolean)[];
+          functionArgs: (string | number | boolean)[];
           errorMessage: string;
           testCaller: [string, string];
         }) => {
@@ -569,7 +565,7 @@ describe("Custom reporter logging", () => {
                 testContractId: testContractId,
                 selectedTestFunction:
                   r.selectedTestFunction as any as ContractInterfaceFunction,
-                functionArgsArb: r.functionArgsArb,
+                functionArgs: r.functionArgs,
                 testCaller: r.testCaller,
               },
             ],
@@ -589,7 +585,7 @@ describe("Custom reporter logging", () => {
               testContractId
             )}`,
             `- Test Function : ${r.selectedTestFunction.name} (${r.selectedTestFunction.access})`,
-            `- Arguments     : ${JSON.stringify(r.functionArgsArb)}`,
+            `- Arguments     : ${JSON.stringify(r.functionArgs)}`,
             `- Caller        : ${r.testCaller[0]}`,
             `- Outputs       : ${JSON.stringify(
               r.selectedTestFunction.outputs
@@ -628,9 +624,7 @@ describe("Custom reporter logging", () => {
             outputs: fc.array(fc.ascii()),
             args: fc.anything(),
           }),
-          functionArgsArb: fc.array(
-            fc.oneof(fc.ascii(), fc.nat(), fc.boolean())
-          ),
+          functionArgs: fc.array(fc.oneof(fc.ascii(), fc.nat(), fc.boolean())),
           errorMessage: fc.ascii(),
           testCaller: fc.constantFrom(
             ...new Map(
@@ -649,7 +643,7 @@ describe("Custom reporter logging", () => {
             outputs: string[];
             args: any;
           };
-          functionArgsArb: (string | number | boolean)[];
+          functionArgs: (string | number | boolean)[];
           errorMessage: string;
           testCaller: [string, string];
         }) => {
@@ -670,7 +664,7 @@ describe("Custom reporter logging", () => {
                 testContractId: testContractId,
                 selectedTestFunction:
                   r.selectedTestFunction as any as ContractInterfaceFunction,
-                functionArgsArb: r.functionArgsArb,
+                functionArgs: r.functionArgs,
                 testCaller: r.testCaller,
               },
             ],

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -70,7 +70,12 @@ export function reporter(
             )
             .join(", ")}`
         );
-        radio.emit("logFailure", `- Caller   : ${r.sutCaller[0]}`);
+        radio.emit(
+          "logFailure",
+          `- Callers  : ${r.sutCallers
+            .map((sutCaller: [string, string]) => sutCaller[0])
+            .join(", ")}`
+        );
         radio.emit(
           "logFailure",
           `- Outputs  : ${r.selectedFunctions

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -1,7 +1,12 @@
-import { green } from "ansicolor";
 import { EventEmitter } from "events";
-import { getContractNameFromContractId } from "./shared";
 import { ContractInterfaceFunction } from "@hirosystems/clarinet-sdk-wasm";
+import { green } from "ansicolor";
+import {
+  InvariantCounterExample,
+  RunDetails,
+  TestCounterExample,
+} from "./heatstroke.types";
+import { getContractNameFromContractId } from "./shared";
 
 /**
  * Heatstrokes Reporter
@@ -21,15 +26,12 @@ import { ContractInterfaceFunction } from "@hirosystems/clarinet-sdk-wasm";
  * @returns void
  */
 export function reporter(
-  //@ts-ignore
-  runDetails,
+  runDetails: RunDetails,
   radio: EventEmitter,
   type: "invariant" | "test"
 ) {
   if (runDetails.failed) {
     // Report general run data.
-    const r = runDetails.counterexample[0];
-
     radio.emit(
       "logFailure",
       `\nError: Property failed after ${runDetails.numRuns} tests.`
@@ -40,6 +42,7 @@ export function reporter(
     }
     switch (type) {
       case "invariant": {
+        const r = runDetails.counterexample[0] as InvariantCounterExample;
         // Report specific run data for the invariant testing type.
         radio.emit("logFailure", `\nCounterexample:`);
         radio.emit(
@@ -113,6 +116,8 @@ export function reporter(
         break;
       }
       case "test": {
+        const r = runDetails.counterexample[0] as TestCounterExample;
+
         // Report specific run data for the property testing type.
         radio.emit("logFailure", `\nCounterexample:`);
         radio.emit(

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -130,7 +130,7 @@ export function reporter(
         );
         radio.emit(
           "logFailure",
-          `- Arguments     : ${JSON.stringify(r.functionArgsArb)}`
+          `- Arguments     : ${JSON.stringify(r.functionArgs)}`
         );
         radio.emit("logFailure", `- Caller        : ${r.testCaller[0]}`);
         radio.emit(

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -107,7 +107,6 @@ export function reporter(
         }" returned:\n\n${runDetails.error
           ?.toString()
           .split("\n")
-          // @ts-ignore
           .map((line) => "    " + line)
           .join("\n")}\n`;
 
@@ -148,7 +147,6 @@ export function reporter(
         }" returned:\n\n${runDetails.error
           ?.toString()
           .split("\n")
-          // @ts-ignore
           .map((line) => "    " + line)
           .join("\n")}\n`;
 

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -1,6 +1,7 @@
 import { green } from "ansicolor";
 import { EventEmitter } from "events";
 import { getContractNameFromContractId } from "./shared";
+import { ContractInterfaceFunction } from "@hirosystems/clarinet-sdk-wasm";
 
 /**
  * Heatstrokes Reporter
@@ -49,16 +50,34 @@ export function reporter(
         );
         radio.emit(
           "logFailure",
-          `- Function : ${r.selectedFunction.name} (${r.selectedFunction.access})`
+          `- Functions: ${r.selectedFunctions
+            .map(
+              (selectedFunction: ContractInterfaceFunction) =>
+                selectedFunction.name
+            )
+            .join(", ")} (${r.selectedFunctions
+            .map(
+              (selectedFunction: ContractInterfaceFunction) =>
+                selectedFunction.access
+            )
+            .join(", ")})`
         );
         radio.emit(
           "logFailure",
-          `- Arguments: ${JSON.stringify(r.functionArgsArb)}`
+          `- Arguments: ${r.selectedFunctionsArgsList
+            .map((selectedFunctionArgs: any[]) =>
+              JSON.stringify(selectedFunctionArgs)
+            )
+            .join(", ")}`
         );
         radio.emit("logFailure", `- Caller   : ${r.sutCaller[0]}`);
         radio.emit(
           "logFailure",
-          `- Outputs  : ${JSON.stringify(r.selectedFunction.outputs)}`
+          `- Outputs  : ${r.selectedFunctions
+            .map((selectedFunction: ContractInterfaceFunction) =>
+              JSON.stringify(selectedFunction.outputs)
+            )
+            .join(", ")}`
         );
         radio.emit(
           "logFailure",
@@ -66,7 +85,7 @@ export function reporter(
         );
         radio.emit(
           "logFailure",
-          `- Arguments: ${JSON.stringify(r.invariantArgsArb)}`
+          `- Arguments: ${JSON.stringify(r.invariantArgs)}`
         );
         radio.emit("logFailure", `- Caller   : ${r.invariantCaller[0]}`);
 

--- a/heatstroke.types.ts
+++ b/heatstroke.types.ts
@@ -14,7 +14,7 @@ type CounterExample = TestCounterExample | InvariantCounterExample;
 export type TestCounterExample = {
   testContractId: string;
   selectedTestFunction: ContractInterfaceFunction;
-  functionArgsArb: any;
+  functionArgs: any;
   testCaller: [string, string];
 };
 

--- a/heatstroke.types.ts
+++ b/heatstroke.types.ts
@@ -1,0 +1,29 @@
+import { ContractInterfaceFunction } from "@hirosystems/clarinet-sdk-wasm";
+
+export type RunDetails = {
+  failed: boolean;
+  counterexample: CounterExample[];
+  numRuns: number;
+  seed: number;
+  path?: string;
+  error: Error;
+};
+
+type CounterExample = TestCounterExample | InvariantCounterExample;
+
+export type TestCounterExample = {
+  testContractId: string;
+  selectedTestFunction: ContractInterfaceFunction;
+  functionArgsArb: any;
+  testCaller: [string, string];
+};
+
+export type InvariantCounterExample = {
+  rendezvousContractId: string;
+  selectedFunctions: ContractInterfaceFunction[];
+  selectedFunctionsArgsList: any[];
+  sutCallers: [string, string][];
+  selectedInvariant: ContractInterfaceFunction;
+  invariantArgs: any;
+  invariantCaller: [string, string];
+};

--- a/invariant.ts
+++ b/invariant.ts
@@ -242,7 +242,7 @@ export const checkInvariants = (
             .map((burnBlocks) => ({ ...r, ...burnBlocks }))
         ),
       (r) => {
-        const selectedFunctionArgsCV = r.selectedFunctions.map(
+        const selectedFunctionsArgsCV = r.selectedFunctions.map(
           (selectedFunction, index) =>
             argsToCV(selectedFunction, r.selectedFunctionsArgsList[index])
         );
@@ -270,7 +270,7 @@ export const checkInvariants = (
             const { result: functionCallResult } = simnet.callPublicFn(
               r.rendezvousContractId,
               selectedFunction.name,
-              selectedFunctionArgsCV[index],
+              selectedFunctionsArgsCV[index],
               sutCallerAddress
             );
 

--- a/invariant.ts
+++ b/invariant.ts
@@ -179,7 +179,6 @@ export const checkInvariants = (
           // to the first contract in the list. The arbitrary is still needed,
           // being used for reporting purposes in `heatstroke.ts`.
           rendezvousContractId: fc.constant(rendezvousContractId),
-          sutCaller: fc.constantFrom(...eligibleAccounts.entries()),
           invariantCaller: fc.constantFrom(...eligibleAccounts.entries()),
           canMineBlocks: fc.boolean(),
         })
@@ -196,6 +195,13 @@ export const checkInvariants = (
         .chain((r) =>
           fc
             .record({
+              sutCallers: fc.array(
+                fc.constantFrom(...eligibleAccounts.entries()),
+                {
+                  minLength: r.selectedFunctions.length,
+                  maxLength: r.selectedFunctions.length,
+                }
+              ),
               selectedFunctionsArgsList: fc.tuple(
                 ...r.selectedFunctions.map((selectedFunction) =>
                   fc.tuple(
@@ -245,10 +251,9 @@ export const checkInvariants = (
           r.invariantArgs
         );
 
-        // TODO: Generate a different wallet for each SUT function call.
-        const [sutCallerWallet, sutCallerAddress] = r.sutCaller;
-
         r.selectedFunctions.forEach((selectedFunction, index) => {
+          const [sutCallerWallet, sutCallerAddress] = r.sutCallers[index];
+
           const printedFunctionArgs = r.selectedFunctionsArgsList[index]
             .map((arg) => {
               try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4079,9 +4079,10 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
-      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/property.ts
+++ b/property.ts
@@ -187,7 +187,7 @@ export const checkProperties = (
         .chain((r) =>
           fc
             .record({
-              functionArgsArb: fc.tuple(
+              functionArgs: fc.tuple(
                 ...functionToArbitrary(
                   r.selectedTestFunction,
                   simnetAddresses,
@@ -218,10 +218,10 @@ export const checkProperties = (
       (r) => {
         const selectedTestFunctionArgs = argsToCV(
           r.selectedTestFunction,
-          r.functionArgsArb
+          r.functionArgs
         );
 
-        const printedTestFunctionArgs = r.functionArgsArb
+        const printedTestFunctionArgs = r.functionArgs
           .map((arg) => {
             try {
               return typeof arg === "object"


### PR DESCRIPTION
This PR allows multiple public functions from the target contract to be called during an invariant testing run. This way, more state transitions can be caused in fewer runs.

**Example Output**
```
₿     1006 Ӿ     1084   wallet_5        counter decrement 
₿     1006 Ӿ     1086   wallet_3        counter add 198869171
₿     1006 Ӿ     1088   wallet_3        counter add 1627479458
₿     1006 Ӿ     1090   wallet_2        counter increment 
₿     1006 Ӿ     1092   wallet_6        counter decrement 
₿     1006 Ӿ     1092   wallet_4 [PASS] counter invariant-counter-gt-zero 
₿     1293 Ӿ     1381   wallet_2        counter decrement 
₿     1293 Ӿ     1383   wallet_1        counter increment 
₿     1293 Ӿ     1385   wallet_1        counter increment 
₿     1293 Ӿ     1387   wallet_3        counter increment 
₿     1293 Ӿ     1389   wallet_2        counter increment 
₿     1293 Ӿ     1391   wallet_3        counter increment 
₿     1293 Ӿ     1393   wallet_6        counter decrement 
₿     1293 Ӿ     1395   deployer        counter add 4
₿     1293 Ӿ     1397   deployer        counter decrement 
₿     1293 Ӿ     1399   deployer        counter increment 
₿     1293 Ӿ     1401   deployer        counter increment 
₿     1293 Ӿ     1403   wallet_3        counter decrement 
₿     1293 Ӿ     1403   wallet_4 [PASS] counter invariant-counter-gt-zero 
₿     1646 Ӿ     1758   wallet_8        counter add 2084438653
₿     1646 Ӿ     1758   wallet_7 [PASS] counter invariant-counter-gt-zero 
```
This PR resolves #98.