### PR TITLE
Update ts-jest to remove deprecated dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@hirosystems/clarinet-sdk-wasm": "2.12.0",
         "@types/jest": "^29.5.12",
         "jest": "^29.7.0",
-        "ts-jest": "^29.2.3",
+        "ts-jest": "^29.2.5",
         "typescript": "^5.5.4"
       }
     },
@@ -2420,6 +2420,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@hirosystems/clarinet-sdk-wasm": "2.12.0",
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.3",
+    "ts-jest": "^29.2.5",
     "typescript": "^5.5.4"
   }
 }


### PR DESCRIPTION
Removes warnings for inflight@1.0.6 and glob@7.2.3. See https://github.com/stacks-network/rendezvous/commit/4d0d7c5742e3ef6e8e2fde996d0d9ccc1fe6c9ce.