### PR TITLE
Custom manifest file support

### DIFF
--- a/app.tests.ts
+++ b/app.tests.ts
@@ -1,5 +1,5 @@
 import { red } from "ansicolor";
-import { main } from "./app";
+import { getManifestFileName, main } from "./app";
 import { version } from "./package.json";
 
 describe("Command-line arguments handling", () => {
@@ -365,4 +365,18 @@ describe("Command-line arguments handling", () => {
       jest.restoreAllMocks();
     }
   );
+});
+
+describe("Custom manifest detection", () => {
+  it("returns the default manifest file name for the example project", () => {
+    // Arrange
+    const manifestDir = "example";
+    const targetContractName = "counter";
+
+    // Act
+    const actual = getManifestFileName(manifestDir, targetContractName);
+
+    // Assert
+    expect(actual).toBe("Clarinet.toml");
+  });
 });

--- a/citizen.tests.ts
+++ b/citizen.tests.ts
@@ -12,6 +12,7 @@ import { join } from "path";
 import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import yaml from "yaml";
+import { getManifestFileName } from "./app";
 
 describe("Simnet deployment plan operations", () => {
   const manifestDir = "example";
@@ -337,7 +338,11 @@ describe("Simnet deployment plan operations", () => {
     cpSync(manifestDir, tempDir, { recursive: true });
 
     // Exercise
-    const firstClassSimnet = await issueFirstClassCitizenship(tempDir, "cargo");
+    const firstClassSimnet = await issueFirstClassCitizenship(
+      tempDir,
+      join(tempDir, getManifestFileName(tempDir, "cargo")),
+      "cargo"
+    );
     const actual = firstClassSimnet.getContractSource("cargo");
 
     // Verify

--- a/citizen.ts
+++ b/citizen.ts
@@ -20,16 +20,16 @@ import {
  *   to the simnet.
  *
  * @param manifestDir The relative path to the manifest directory.
+ * @param manifestPath The absolute path to the manifest file.
  * @param sutContractName The target contract name.
  * @returns The initialized simnet instance with all contracts deployed, with
  * the test contract treated as a first-class citizen of the target contract.
  */
 export const issueFirstClassCitizenship = async (
   manifestDir: string,
+  manifestPath: string,
   sutContractName: string
 ): Promise<Simnet> => {
-  const manifestPath = join(manifestDir, "Clarinet.toml");
-
   // Initialize the simnet, to generate the simnet plan and instance. The empty
   // session will be set up, and contracts will be deployed in the correct
   // order based on the simnet plan a few lines below.

--- a/invariant.tests.ts
+++ b/invariant.tests.ts
@@ -8,6 +8,7 @@ import {
 import { join } from "path";
 import { issueFirstClassCitizenship } from "./citizen";
 import { Cl } from "@stacks/transactions";
+import { getManifestFileName } from "./app";
 
 describe("Simnet contracts operations", () => {
   it("correctly initializes the local context for a given functions map", async () => {
@@ -39,7 +40,11 @@ describe("Simnet contracts operations", () => {
 
   it("correctly initializes the Clarity context", async () => {
     // Arrange
-    const simnet = await issueFirstClassCitizenship("example", "counter");
+    const simnet = await issueFirstClassCitizenship(
+      "example",
+      join("example", getManifestFileName("example", "counter")),
+      "counter"
+    );
 
     const rendezvousList = Array.from(
       getSimnetDeployerContractsInterfaces(simnet).keys()


### PR DESCRIPTION
This PR adds support for custom manifest files for each target contract. To use one, place a file named `Clarinet-<contract-name>.toml` in the target Clarinet project's root.

### Example  
For the command:  
```sh
npx rv sbtc/contracts sbtc-token invariant
```  
Rendezvous will check for `sbtc-token/contracts/Clarinet-sbtc-token.toml`. If found, it will be used to initialize the `Simnet`. If not, the default `Clarinet.toml` will be used.

### Real-World Use Case  
When fuzzing `sbtc-token`, a user may need to replace `sbtc-registry` with a test double. This allows bypassing the `is-protocol-caller` check, enabling state transitions.

#### Original `sbtc-registry.clar`
[See sbtc-registry](https://github.com/stacks-network/sbtc/blob/1b9e1f07f90d4f1f63cc6d91a6d45b33a6febb40/contracts/contracts/sbtc-registry.clar#L360-L369)
```clarity
(define-read-only (is-protocol-caller (contract-flag (buff 1)) (contract principal))
  (begin
    (asserts! (is-eq (some contract) (map-get? active-protocol-contracts contract-flag)) ERR_UNAUTHORIZED)
    (asserts! (is-eq (some contract-flag) (map-get? active-protocol-roles contract)) ERR_UNAUTHORIZED)
    (ok true)
  )
)
```
#### Test Double `sbtc-registry-double.clar`
```clarity
(define-constant deployer tx-sender)

(define-read-only (is-protocol-caller (contract-flag (buff 1)) (contract principal))
  (begin
    (asserts! (is-eq tx-sender deployer) ERR_UNAUTHORIZED)
    (ok true)
  )
)
```

#### Rendezvous Property Test `sbtc-token.tests.clar`
```clarity
(define-public (test-protocol-set-token-uri
    (new-uri (optional (string-utf8 256)))
    (contract-flag (buff 1))
  )
  (let (
      (initial-uri (unwrap-panic (get-token-uri)))
    )
    (ok
      (if
        (or
          (not (is-eq tx-sender deployer))
          (is-eq initial-uri new-uri)
        )
        false
        (begin
          (try! (protocol-set-token-uri new-uri contract-flag))
          (asserts!
            (is-eq
              (unwrap-panic (get-token-uri))
              new-uri
            )
            ERR_FAILED_ASSERTION
          )
          true
        )
      )
    )
  )
)
```
### Custom Manifest Setup  
To use the test double, create a custom manifest file:  
```toml
# Clarinet-sbtc-token.toml
# unchanged...
[contracts.sbtc-registry]
path = 'contracts/sbtc-registry-double.clar'
clarity_version = 3
epoch = 3.0
# unchanged...
```

This PR can represent a solution for #97, where @moodmosaic pointed out the Test Doubles approach in https://github.com/stacks-network/rendezvous/issues/97#issuecomment-2614610694.