### PR TITLE
Add support for `dialers` in invariant testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ npx rv <path-to-clarinet-project> <contract-name> <type>
 - `--path` – The path to use for the replay functionality.
 - `--runs` – The number of test iterations to use for exercising the contracts.
   (default: `100`)
+- `--dial` – The path to a JavaScript file containing custom pre- and
+  post-execution functions (dialers).
 
 ---
 

--- a/app.tests.ts
+++ b/app.tests.ts
@@ -10,7 +10,7 @@ describe("Command-line arguments handling", () => {
   const helpMessage = `
   rv v${version}
   
-  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>]
+  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>] [--dial=<path-to-dialers-file>]
 
   Positional arguments:
     path-to-clarinet-project - The path to the Clarinet project.
@@ -21,6 +21,7 @@ describe("Command-line arguments handling", () => {
     --seed - The seed to use for the replay functionality.
     --path - The path to use for the replay functionality.
     --runs - The runs to use for iterating over the tests. Default: 100.
+    --dial – The path to a JavaScript file containing custom pre- and post-execution functions (dialers).
     --help - Show the help message.
   `;
   const noManifestMessage = red(

--- a/app.tests.ts
+++ b/app.tests.ts
@@ -10,7 +10,7 @@ describe("Command-line arguments handling", () => {
   const helpMessage = `
   rv v${version}
   
-  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>] [--dial=<path-to-dialers-file>]
+  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>] [--dial=<path-to-dialers-file>] [--help]
 
   Positional arguments:
     path-to-clarinet-project - The path to the Clarinet project.

--- a/app.tests.ts
+++ b/app.tests.ts
@@ -197,6 +197,23 @@ describe("Command-line arguments handling", () => {
       ],
     ],
     [
+      ["manifest path", "contract name", "type=invariant", "dialers file path"],
+      [
+        "node",
+        "app.js",
+        "example",
+        "counter",
+        "invariant",
+        "--dial=example/sip010.js",
+      ],
+      [
+        `Using manifest path: example/Clarinet.toml`,
+        `Target contract: counter`,
+        `Using dial path: example/sip010.js`,
+        `\nStarting invariant testing type for the counter contract...\n`,
+      ],
+    ],
+    [
       ["manifest path", "contract name", "type=test"],
       ["node", "app.js", "example", "counter", "test"],
       [

--- a/app.ts
+++ b/app.ts
@@ -44,7 +44,7 @@ export const getManifestFileName = (
 const helpMessage = `
   rv v${version}
   
-  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>]
+  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>] [--dial=<path-to-dialers-file>]
 
   Positional arguments:
     path-to-clarinet-project - The path to the Clarinet project.
@@ -55,6 +55,7 @@ const helpMessage = `
     --seed - The seed to use for the replay functionality.
     --path - The path to use for the replay functionality.
     --runs - The runs to use for iterating over the tests. Default: 100.
+    --dial – The path to a JavaScript file containing custom pre- and post-execution functions (dialers).
     --help - Show the help message.
   `;
 

--- a/app.ts
+++ b/app.ts
@@ -44,7 +44,7 @@ export const getManifestFileName = (
 const helpMessage = `
   rv v${version}
   
-  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>] [--dial=<path-to-dialers-file>]
+  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>] [--dial=<path-to-dialers-file>] [--help]
 
   Positional arguments:
     path-to-clarinet-project - The path to the Clarinet project.

--- a/citizen.ts
+++ b/citizen.ts
@@ -216,9 +216,9 @@ export const buildRendezvousData = (
       rendezvousSource: rendezvousSource,
       rendezvousContractName: contractName,
     };
-  } catch (e: any) {
+  } catch (error: any) {
     throw new Error(
-      `Error processing "${contractName}" contract: ${e.message}`
+      `Error processing "${contractName}" contract: ${error.message}`
     );
   }
 };
@@ -295,9 +295,9 @@ export const getTestContractSource = (
     return readFileSync(join(manifestDir, testContractPath), {
       encoding: "utf-8",
     }).toString();
-  } catch (e: any) {
+  } catch (error: any) {
     throw new Error(
-      `Error retrieving the corresponding test contract for the "${sutContractName}" contract. ${e.message}`
+      `Error retrieving the corresponding test contract for the "${sutContractName}" contract. ${error.message}`
     );
   }
 };

--- a/dialer.tests.ts
+++ b/dialer.tests.ts
@@ -1,0 +1,88 @@
+import { join } from "path";
+import { DialerRegistry } from "./dialer";
+import { existsSync } from "fs";
+
+const dialPath = join("example", "dialer.ts");
+
+describe("DialerRegistry interaction", () => {
+  it("initializes the dialer registry with the dialer file", async () => {
+    // Act
+    const actual = new DialerRegistry(dialPath);
+
+    // Assert
+    expect(actual).toBeInstanceOf(DialerRegistry);
+  });
+
+  it("correctly executes registered pre-dialer", async () => {
+    // Arrange
+    const mockPreDialer = jest.fn();
+    const dialerRegistry = new DialerRegistry(dialPath);
+    dialerRegistry.registerPreDialer(mockPreDialer);
+
+    // Act
+    await dialerRegistry.executePreDialers({});
+
+    // Assert
+    expect(mockPreDialer).toHaveBeenCalledTimes(1);
+  });
+
+  it("correctly executes registered post-dialer", async () => {
+    // Arrange
+    const mockPostDialer = jest.fn();
+    const dialerRegistry = new DialerRegistry(dialPath);
+    dialerRegistry.registerPostDialer(mockPostDialer);
+
+    // Act
+    await dialerRegistry.executePostDialers({});
+
+    // Assert
+    expect(mockPostDialer).toHaveBeenCalledTimes(1);
+  });
+
+  it("all the pre-dialers are executed", async () => {
+    // Arrange
+    const mockPreDialer1 = jest.fn();
+    const mockPreDialer2 = jest.fn();
+    const registry = new DialerRegistry(dialPath);
+
+    registry.registerPreDialer(mockPreDialer1);
+    registry.registerPreDialer(mockPreDialer2);
+
+    // Act
+    await registry.executePreDialers({});
+
+    // Assert
+    expect(mockPreDialer1).toHaveBeenCalledTimes(1);
+    expect(mockPreDialer2).toHaveBeenCalledTimes(1);
+  });
+
+  it("all the post-dialers are executed", async () => {
+    // Arrange
+    const mockPostDialer1 = jest.fn();
+    const mockPostDialer2 = jest.fn();
+    const registry = new DialerRegistry(dialPath);
+
+    registry.registerPostDialer(mockPostDialer1);
+    registry.registerPostDialer(mockPostDialer2);
+
+    // Act
+    await registry.executePostDialers({});
+
+    // Assert
+    expect(mockPostDialer1).toHaveBeenCalledTimes(1);
+    expect(mockPostDialer2).toHaveBeenCalledTimes(1);
+  });
+
+  it("early exits when specified dialer file is not found", async () => {
+    // Arrange
+    jest.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit was called");
+    });
+    const registry = new DialerRegistry("non-existent.js");
+
+    // Act & Assert
+    expect(registry.registerDialers()).rejects.toThrow(
+      "process.exit was called"
+    );
+  });
+});

--- a/dialer.tests.ts
+++ b/dialer.tests.ts
@@ -1,4 +1,5 @@
 import { join } from "path";
+import { DialerContext } from "./dialer.types";
 import { DialerRegistry } from "./dialer";
 
 const dialPath = join("example", "dialer.ts");
@@ -15,11 +16,11 @@ describe("DialerRegistry interaction", () => {
   it("correctly executes registered pre-dialer", async () => {
     // Arrange
     const mockPreDialer = jest.fn();
-    const dialerRegistry = new DialerRegistry(dialPath);
-    dialerRegistry.registerPreDialer(mockPreDialer);
+    const registry = new DialerRegistry(dialPath);
+    registry.registerPreDialer(mockPreDialer);
 
     // Act
-    await dialerRegistry.executePreDialers({});
+    await registry.executePreDialers({} as any as DialerContext);
 
     // Assert
     expect(mockPreDialer).toHaveBeenCalledTimes(1);
@@ -28,11 +29,11 @@ describe("DialerRegistry interaction", () => {
   it("correctly executes registered post-dialer", async () => {
     // Arrange
     const mockPostDialer = jest.fn();
-    const dialerRegistry = new DialerRegistry(dialPath);
-    dialerRegistry.registerPostDialer(mockPostDialer);
+    const registry = new DialerRegistry(dialPath);
+    registry.registerPostDialer(mockPostDialer);
 
     // Act
-    await dialerRegistry.executePostDialers({});
+    await registry.executePostDialers({} as any as DialerContext);
 
     // Assert
     expect(mockPostDialer).toHaveBeenCalledTimes(1);
@@ -48,7 +49,7 @@ describe("DialerRegistry interaction", () => {
     registry.registerPreDialer(mockPreDialer2);
 
     // Act
-    await registry.executePreDialers({});
+    await registry.executePreDialers({} as any as DialerContext);
 
     // Assert
     expect(mockPreDialer1).toHaveBeenCalledTimes(1);
@@ -65,7 +66,7 @@ describe("DialerRegistry interaction", () => {
     registry.registerPostDialer(mockPostDialer2);
 
     // Act
-    await registry.executePostDialers({});
+    await registry.executePostDialers({} as any as DialerContext);
 
     // Assert
     expect(mockPostDialer1).toHaveBeenCalledTimes(1);

--- a/dialer.tests.ts
+++ b/dialer.tests.ts
@@ -1,6 +1,5 @@
 import { join } from "path";
 import { DialerRegistry } from "./dialer";
-import { existsSync } from "fs";
 
 const dialPath = join("example", "dialer.ts");
 

--- a/dialer.ts
+++ b/dialer.ts
@@ -69,3 +69,17 @@ export class DialerRegistry {
     }
   }
 }
+
+export class PreDialerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "Pre-dialer error";
+  }
+}
+
+export class PostDialerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "Post-dialer error";
+  }
+}

--- a/dialer.ts
+++ b/dialer.ts
@@ -2,6 +2,10 @@ import { existsSync } from "fs";
 import { resolve } from "path";
 import { Dialer, DialerContext } from "./dialer.types";
 
+// In telephony, a registry is used for maintaining a known set of handlers,
+// devices, or processes. This aligns with this class's purpose. Dialers are
+// loaded/stored and run in a structured way, so "registry" fits both telephony
+// and DI semantics.
 export class DialerRegistry {
   private readonly dialPath: string;
   private preDialers: Dialer[] = [];

--- a/dialer.ts
+++ b/dialer.ts
@@ -3,7 +3,7 @@ import { resolve } from "path";
 import { Dialer, DialerContext } from "./dialer.types";
 
 export class DialerRegistry {
-  private dialPath: string;
+  private readonly dialPath: string;
   private preDialers: Dialer[] = [];
   private postDialers: Dialer[] = [];
 

--- a/dialer.ts
+++ b/dialer.ts
@@ -1,0 +1,68 @@
+import { existsSync } from "fs";
+import { resolve } from "path";
+
+type Dialer = (context: any) => Promise<void> | void;
+
+export class DialerRegistry {
+  private dialPath: string;
+  private preDialers: Dialer[] = [];
+  private postDialers: Dialer[] = [];
+
+  constructor(dialPath: string) {
+    this.dialPath = dialPath;
+  }
+
+  registerPreDialer(dialer: Dialer) {
+    this.preDialers.push(dialer);
+  }
+
+  registerPostDialer(dialer: Dialer) {
+    this.postDialers.push(dialer);
+  }
+
+  async registerDialers() {
+    const resolvedDialPath = resolve(this.dialPath);
+
+    if (!existsSync(resolvedDialPath)) {
+      console.error(`Error: Dialer file not found: ${resolvedDialPath}`);
+      process.exit(1);
+    }
+
+    try {
+      const userModule = await import(resolvedDialPath);
+
+      Object.entries(userModule).forEach(([key, fn]) => {
+        if (typeof fn === "function") {
+          if (key.startsWith("pre")) {
+            this.registerPreDialer(fn as Dialer);
+          } else if (key.startsWith("post")) {
+            this.registerPostDialer(fn as Dialer);
+          }
+        }
+      });
+    } catch (error) {
+      console.error(`Failed to load dialers:`, error);
+      process.exit(1);
+    }
+  }
+
+  async executePreDialers(context: any) {
+    if (this.preDialers.length === 0) {
+      return;
+    }
+
+    for (const dial of this.preDialers) {
+      await dial(context);
+    }
+  }
+
+  async executePostDialers(context: any) {
+    if (this.postDialers.length === 0) {
+      return;
+    }
+
+    for (const dial of this.postDialers) {
+      await dial(context);
+    }
+  }
+}

--- a/dialer.ts
+++ b/dialer.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "fs";
 import { resolve } from "path";
-import { Dialer } from "./dialer.types";
+import { Dialer, DialerContext } from "./dialer.types";
 
 export class DialerRegistry {
   private dialPath: string;
@@ -45,7 +45,7 @@ export class DialerRegistry {
     }
   }
 
-  async executePreDialers(context: any) {
+  async executePreDialers(context: DialerContext) {
     if (this.preDialers.length === 0) {
       return;
     }
@@ -55,7 +55,7 @@ export class DialerRegistry {
     }
   }
 
-  async executePostDialers(context: any) {
+  async executePostDialers(context: DialerContext) {
     if (this.postDialers.length === 0) {
       return;
     }

--- a/dialer.ts
+++ b/dialer.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "fs";
 import { resolve } from "path";
-
-type Dialer = (context: any) => Promise<void> | void;
+import { Dialer } from "./dialer.types";
 
 export class DialerRegistry {
   private dialPath: string;

--- a/dialer.types.ts
+++ b/dialer.types.ts
@@ -1,0 +1,11 @@
+import { ParsedTransactionResult } from "@hirosystems/clarinet-sdk";
+import { ClarityValue } from "@stacks/transactions";
+import { EnrichedContractInterfaceFunction } from "./shared.types";
+
+export type Dialer = (context: DialerContext) => Promise<void> | void;
+
+type DialerContext = {
+  clarityValueArguments: ClarityValue[];
+  functionCall: ParsedTransactionResult;
+  selectedFunction: EnrichedContractInterfaceFunction;
+};

--- a/dialer.types.ts
+++ b/dialer.types.ts
@@ -4,7 +4,7 @@ import { EnrichedContractInterfaceFunction } from "./shared.types";
 
 export type Dialer = (context: DialerContext) => Promise<void> | void;
 
-type DialerContext = {
+export type DialerContext = {
   clarityValueArguments: ClarityValue[];
   functionCall: ParsedTransactionResult;
   selectedFunction: EnrichedContractInterfaceFunction;

--- a/dialer.types.ts
+++ b/dialer.types.ts
@@ -6,6 +6,6 @@ export type Dialer = (context: DialerContext) => Promise<void> | void;
 
 export type DialerContext = {
   clarityValueArguments: ClarityValue[];
-  functionCall: ParsedTransactionResult;
+  functionCall: ParsedTransactionResult | undefined;
   selectedFunction: EnrichedContractInterfaceFunction;
 };

--- a/example/contracts/rendezvous-token.clar
+++ b/example/contracts/rendezvous-token.clar
@@ -2,6 +2,10 @@
 
 (define-fungible-token rendezvous)
 
+(define-constant deployer tx-sender)
+
+(define-constant ERR_UNAUTHORIZED (err u400))
+
 ;; SIP-010 methods.
 
 (define-read-only (get-total-supply)
@@ -34,8 +38,22 @@
     (recipient principal)
     (memo (optional (buff 34)))
   )
-  (match (ft-transfer? rendezvous amount sender recipient)
-    response (ok response)
-    error (err error)
+  (begin
+    ;; This print event is required for rendezvous to be a SIP-010 compliant
+    ;; fungible token. Comment out this line and run the following command to
+    ;; see the `dialers` in action:
+    ;; ```rv example rendezvous-token invariant --dial=example/sip010.js```
+    (match memo to-print (print to-print) 0x)
+    (match (ft-transfer? rendezvous amount sender recipient)
+      response (ok response)
+      error (err error)
+    )
+  )
+)
+
+(define-public (mint (recipient principal) (amount uint))
+  (begin
+    (asserts! (is-eq contract-caller deployer) ERR_UNAUTHORIZED)
+    (ft-mint? rendezvous amount recipient)
   )
 )

--- a/example/contracts/rendezvous-token.tests.clar
+++ b/example/contracts/rendezvous-token.tests.clar
@@ -1,0 +1,7 @@
+;; Invariants
+
+;; This invariant returns true regardless of the state of the contract. Its
+;; purpose is to allow the demonstration of the `dialers` feature.
+(define-read-only (invariant-always-true)
+  true
+)

--- a/example/sip010.js
+++ b/example/sip010.js
@@ -4,8 +4,10 @@
 //
 // This is just an example of the power of custom dialers. In sBTC, the
 // transfer function did not emit the print event, resulting in sBTC not being
-// SIP-010 compliant. This custom dialer allows for the detection of such
-// issues for any fungible token contract in the future.
+// SIP-010 compliant: https://github.com/stacks-network/sbtc/issues/1090.
+//
+// This custom dialer allows for the detection of such issues for any fungible
+// token contract in the future.
 //
 // References:
 // https://github.com/stacksgov/sips/blob/2c3b36c172c0b71369bc26cffa080e8bdd2b3b84/sips/sip-010/sip-010-fungible-token-standard.md?plain=1#L69

--- a/example/sip010.js
+++ b/example/sip010.js
@@ -1,0 +1,63 @@
+const { cvToHex } = require("@stacks/transactions");
+
+async function postTransferSip010PrintEvent(context) {
+  const selectedFunction = context.selectedFunction;
+  // A fungible token complies with the SIP-010 standard if the transfer event
+  // always emits the print event with the `memo` content.
+  if (selectedFunction.name !== "transfer") {
+    return;
+  }
+
+  const functionCall = context.functionCall;
+  const functionCallEvents = functionCall.events;
+
+  if (functionCallEvents.length === 0) {
+    throw new Error(
+      "No transfer events. The transfer function must emit the SIP-010 print event!"
+    );
+  }
+
+  // The `memo` parameter is the fourth parameter of the `transfer` function.
+  const memoParameterIndex = 3;
+
+  const memoArg = context.clarityValueArguments[memoParameterIndex];
+
+  // The `memo` argument is optional. If `none`, nothing has to be printed.
+  if (memoArg.type === 9) {
+    return;
+  }
+
+  // The `memo` argument must be `some`. Otherwise, the generated clarity
+  // argument is invalid.
+  if (memoArg.type !== 10) {
+    return;
+  }
+
+  // Turn the inner value of the `some` type into a hex to compare it with the
+  // print event data.
+  const hexMemoArgValue = cvToHex(memoArg.value);
+
+  const sip010PrintEvent = functionCallEvents.find(
+    (ev) => ev.event === "print_event"
+  );
+
+  if (!sip010PrintEvent) {
+    throw new Error(
+      "No print event found. The transfer function must emit the SIP-010 print event!"
+    );
+  }
+
+  const sip010PrintEventValue = sip010PrintEvent.data.raw_value;
+
+  if (sip010PrintEventValue !== hexMemoArgValue) {
+    throw new Error(
+      `The print event memo value is not equal to the memo parameter value: ${hexMemoArgValue} !== ${sip010PrintEventValue}`
+    );
+  }
+
+  return;
+}
+
+module.exports = {
+  postTransferSip010PrintEvent,
+};

--- a/example/sip010.js
+++ b/example/sip010.js
@@ -1,41 +1,51 @@
+// This file contains a custom predefined post-dialer that checks the SIP-010
+// transfer function for the print event. For a token to be SIP-010 compliant,
+// its transfer function must emit the print event with the `memo` content.
+//
+// This is just an example of the power of custom dialers. In sBTC, the
+// transfer function did not emit the print event, resulting in sBTC not being
+// SIP-010 compliant. This custom dialer allows for the detection of such
+// issues for any fungible token contract in the future.
+//
+// References:
+// https://github.com/stacksgov/sips/blob/2c3b36c172c0b71369bc26cffa080e8bdd2b3b84/sips/sip-010/sip-010-fungible-token-standard.md?plain=1#L69
+// https://github.com/stacks-network/sbtc/commit/74daed379e9aad73dd09bebb83231f2c48ef4d81
+
 const { cvToHex } = require("@stacks/transactions");
 
 async function postTransferSip010PrintEvent(context) {
   const selectedFunction = context.selectedFunction;
+
   // A fungible token complies with the SIP-010 standard if the transfer event
   // always emits the print event with the `memo` content.
   if (selectedFunction.name !== "transfer") {
     return;
   }
 
-  const functionCall = context.functionCall;
-  const functionCallEvents = functionCall.events;
+  const functionCallEvents = context.functionCall.events;
 
-  if (functionCallEvents.length === 0) {
-    throw new Error(
-      "No transfer events. The transfer function must emit the SIP-010 print event!"
-    );
-  }
-
-  // The `memo` parameter is the fourth parameter of the `transfer` function.
+  // The `memo` parameter is the fourth parameter of the `rendezvous-token`'s
+  // `transfer` function.
   const memoParameterIndex = 3;
 
-  const memoArg = context.clarityValueArguments[memoParameterIndex];
+  const memoGeneratedArgumentCV =
+    context.clarityValueArguments[memoParameterIndex];
 
   // The `memo` argument is optional. If `none`, nothing has to be printed.
-  if (memoArg.type === 9) {
+  if (memoGeneratedArgumentCV.type === 9) {
     return;
   }
 
-  // The `memo` argument must be `some`. Otherwise, the generated clarity
-  // argument is invalid.
-  if (memoArg.type !== 10) {
-    return;
+  // If not `none`, the `memo` argument must be `some`. Otherwise, the
+  // generated clarity argument is not an option type, so it does not comply
+  // with the SIP-010 fungible token trait.
+  if (memoGeneratedArgumentCV.type !== 10) {
+    throw new Error("The memo argument has to be an option type!");
   }
 
   // Turn the inner value of the `some` type into a hex to compare it with the
   // print event data.
-  const hexMemoArgValue = cvToHex(memoArg.value);
+  const hexMemoArgumentValue = cvToHex(memoGeneratedArgumentCV.value);
 
   const sip010PrintEvent = functionCallEvents.find(
     (ev) => ev.event === "print_event"
@@ -43,15 +53,15 @@ async function postTransferSip010PrintEvent(context) {
 
   if (!sip010PrintEvent) {
     throw new Error(
-      "No print event found. The transfer function must emit the SIP-010 print event!"
+      "No print event found. The transfer function must emit the SIP-010 print event containing the memo!"
     );
   }
 
   const sip010PrintEventValue = sip010PrintEvent.data.raw_value;
 
-  if (sip010PrintEventValue !== hexMemoArgValue) {
+  if (sip010PrintEventValue !== hexMemoArgumentValue) {
     throw new Error(
-      `The print event memo value is not equal to the memo parameter value: ${hexMemoArgValue} !== ${sip010PrintEventValue}`
+      `The print event memo value is not equal to the memo parameter value: ${hexMemoArgumentValue} !== ${sip010PrintEventValue}`
     );
   }
 

--- a/invariant.ts
+++ b/invariant.ts
@@ -277,8 +277,8 @@ export const checkInvariants = async (
                 clarityValueArguments: selectedFunctionsArgsCV[index],
               });
             }
-          } catch (e: any) {
-            throw new PreDialerError(e.message);
+          } catch (error: any) {
+            throw new PreDialerError(error.message);
           }
 
           try {
@@ -324,8 +324,8 @@ export const checkInvariants = async (
                     clarityValueArguments: selectedFunctionsArgsCV[index],
                   });
                 }
-              } catch (e: any) {
-                throw new PostDialerError(e.message);
+              } catch (error: any) {
+                throw new PostDialerError(error.message);
               }
             } else {
               radio.emit(

--- a/invariant.ts
+++ b/invariant.ts
@@ -18,7 +18,7 @@ import {
   isTraitReferenceFunction,
 } from "./traits";
 import { EnrichedContractInterfaceFunction } from "./shared.types";
-import { DialerRegistry } from "./dialer";
+import { DialerRegistry, PostDialerError, PreDialerError } from "./dialer";
 
 /**
  * Runs invariant testing on the target contract and logs the progress. Reports
@@ -278,7 +278,7 @@ export const checkInvariants = async (
               });
             }
           } catch (e: any) {
-            throw new Error(`Error in pre dialer: ${e.message}`);
+            throw new PreDialerError(e.message);
           }
 
           try {
@@ -325,7 +325,7 @@ export const checkInvariants = async (
                   });
                 }
               } catch (e: any) {
-                throw new Error(`Error in post dialer: ${e.message}`);
+                throw new PostDialerError(e.message);
               }
             } else {
               radio.emit(
@@ -341,12 +341,10 @@ export const checkInvariants = async (
               );
             }
           } catch (error: any) {
-            // If the pre dialer fails, throw an error.
-            if (error.message.startsWith("Error in pre dialer")) {
-              throw error;
-            }
-            // If the post dialer fails, throw an error.
-            if (error.message.startsWith("Error in post dialer")) {
+            if (
+              error instanceof PreDialerError ||
+              error instanceof PostDialerError
+            ) {
               throw error;
             } else {
               // If the function call fails with a runtime error, log a dimmed


### PR DESCRIPTION
This PR introduces support for custom `pre-` and `post-execution` JavaScript functions, called `dialers`, in invariant testing. Dialers run before and after public function calls, allowing users to add custom assertions, behaviors, or side effects during execution. Thanks to @moodmosaic for designing this feature in https://github.com/stacks-network/rendezvous/issues/59#issuecomment-2626703488. Resolves #59.