### PR TITLE
Fix first-class citizenship simnet wallet balances

### DIFF
--- a/citizen.tests.ts
+++ b/citizen.tests.ts
@@ -376,14 +376,10 @@ describe("Simnet deployment plan operations", () => {
     // Verify
     const balancesMap = new Map(
       Array.from([...firstClassSimnet.getAccounts().values()], (address) => {
-        try {
-          const balanceHex = firstClassSimnet.runSnippet(
-            `(stx-get-balance '${address})`
-          );
-          return [address, cvToValue(hexToCV(balanceHex))];
-        } catch (error) {
-          return [address, BigInt(0)];
-        }
+        const balanceHex = firstClassSimnet.runSnippet(
+          `(stx-get-balance '${address})`
+        );
+        return [address, cvToValue(hexToCV(balanceHex))];
       })
     );
 

--- a/citizen.ts
+++ b/citizen.ts
@@ -60,8 +60,6 @@ export const issueFirstClassCitizenship = async (
 
   await simnet.initEmptySession();
 
-  // The `initEmptySession` method will reset the balances of the accounts to
-  // 0. Restore the balances to their original values.
   simnetAddresses.forEach((address) => {
     simnet.mintSTX(address, balancesMap.get(address)!);
   });

--- a/citizen.ts
+++ b/citizen.ts
@@ -49,12 +49,8 @@ export const issueFirstClassCitizenship = async (
 
   const balancesMap = new Map(
     Array.from(simnetAddresses, (address) => {
-      try {
-        const balanceHex = simnet.runSnippet(`(stx-get-balance '${address})`);
-        return [address, cvToValue(hexToCV(balanceHex))];
-      } catch (error) {
-        return [address, BigInt(0)];
-      }
+      const balanceHex = simnet.runSnippet(`(stx-get-balance '${address})`);
+      return [address, cvToValue(hexToCV(balanceHex))];
     })
   );
 


### PR DESCRIPTION
This PR fixes a bug in `issueFirstClassCitizenship`. The `initEmptySession` method did not set wallet balances from `Devnet.toml`, causing all simnet accounts to start with 0 STX. This fix ensures that after initializing a new session, the correct STX balances are minted as specified in `Devnet.toml`.