### PR TITLE
Display the error code for all `[FAIL]` logs in property testing

### DIFF
--- a/property.ts
+++ b/property.ts
@@ -319,8 +319,10 @@ export const checkProperties = (
           } catch (error: any) {
             const displayedError =
               error instanceof PropertyTestError
-                ? error.errorCode
-                : error.includes("Runtime")
+                ? error.clarityError
+                : error &&
+                  typeof error === "string" &&
+                  error.toLowerCase().includes("runtime")
                 ? "(runtime)"
                 : "(unknown)";
 
@@ -487,9 +489,9 @@ export const isReturnTypeBoolean = (
 ) => discardFunctionInterface.outputs.type === "bool";
 
 class PropertyTestError extends Error {
-  readonly errorCode: any;
-  constructor(message: string, errorCode: string) {
+  readonly clarityError: string;
+  constructor(message: string, clarityError: string) {
     super(message);
-    this.errorCode = errorCode;
+    this.clarityError = clarityError;
   }
 }

--- a/property.ts
+++ b/property.ts
@@ -313,7 +313,9 @@ export const checkProperties = (
             }
           } catch (error: any) {
             const displayedError =
-              error instanceof PropertyTestError ? `(err ${error.code})` : "";
+              error instanceof PropertyTestError
+                ? `(err ${error.errorCode})`
+                : "";
             // Capture the error and log the test failure.
             radio.emit(
               "logMessage",
@@ -477,9 +479,9 @@ export const isReturnTypeBoolean = (
 ) => discardFunctionInterface.outputs.type === "bool";
 
 class PropertyTestError extends Error {
-  code: any;
+  readonly errorCode: any;
   constructor(message: string, errorCode: any) {
     super(message);
-    this.code = errorCode;
+    this.errorCode = errorCode;
   }
 }

--- a/property.ts
+++ b/property.ts
@@ -306,11 +306,14 @@ export const checkProperties = (
                 simnet.mineEmptyBurnBlocks(r.burnBlocks);
               }
             } else {
-              throw new Error(
-                `Test failed for ${targetContractName} contract: "${r.selectedTestFunction.name}" returned ${testFunctionCallResultJson.value.value}`
+              throw new PropertyTestError(
+                `Test failed for ${targetContractName} contract: "${r.selectedTestFunction.name}" returned ${testFunctionCallResultJson.value.value}`,
+                testFunctionCallResultJson.value.value
               );
             }
           } catch (error: any) {
+            const displayedError =
+              error instanceof PropertyTestError ? `(err ${error.code})` : "";
             // Capture the error and log the test failure.
             radio.emit(
               "logMessage",
@@ -321,7 +324,8 @@ export const checkProperties = (
                   `[FAIL] ` +
                   `${targetContractName} ` +
                   `${underline(r.selectedTestFunction.name)} ` +
-                  printedTestFunctionArgs
+                  `${printedTestFunctionArgs} ` +
+                  displayedError
               )
             );
 
@@ -471,3 +475,11 @@ export const isParamsMatch = (
 export const isReturnTypeBoolean = (
   discardFunctionInterface: ContractInterfaceFunction
 ) => discardFunctionInterface.outputs.type === "bool";
+
+class PropertyTestError extends Error {
+  code: any;
+  constructor(message: string, errorCode: any) {
+    super(message);
+    this.code = errorCode;
+  }
+}


### PR DESCRIPTION
This PR updates the failure logs in property testing to include the failure error code. Resolves #112. 