### PR TITLE
Adding provenance to npm publish

### DIFF
--- a/.github/workflows/npm-publish-release.yml
+++ b/.github/workflows/npm-publish-release.yml
@@ -6,6 +6,9 @@ jobs:
   publish:
     environment: "Publish to NPM"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -15,6 +18,6 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run build
-      - run: npm publish --access public
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Updates the ci workflow to also publish provenance data to npm:
https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/
https://docs.npmjs.com/generating-provenance-statements
