### PR TITLE
Update `clarinet-sdk-wasm` to `3.0.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "rv": "dist/app.js"
       },
       "devDependencies": {
-        "@hirosystems/clarinet-sdk-wasm": "2.15.2",
+        "@hirosystems/clarinet-sdk-wasm": "^3.0.1",
         "@types/jest": "^29.5.12",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
@@ -910,13 +910,6 @@
       }
     },
     "node_modules/@hirosystems/clarinet-sdk-wasm": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.15.2.tgz",
-      "integrity": "sha512-1Xxq4DfLNO1KbpQso3a4NDr6sHNzGi8Axlxb/3FClSk54BSRv+06HD3QpBN76wjZvzSql/OP4xvFgccz781P6w==",
-      "dev": true,
-      "license": "GPL-3.0"
-    },
-    "node_modules/@hirosystems/clarinet-sdk/node_modules/@hirosystems/clarinet-sdk-wasm": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.0.1.tgz",
       "integrity": "sha512-tygFNX6o/RuEmTuYVP0LwpRCK1dzJaJqehkQP4TCnIGvFIcuoSPm0V6uTZin3N4R7mgLd8VcdkRdu5e45EVfMw==",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "yaml": "^2.6.1"
   },
   "devDependencies": {
-    "@hirosystems/clarinet-sdk-wasm": "2.15.2",
+    "@hirosystems/clarinet-sdk-wasm": "^3.0.1",
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",


### PR DESCRIPTION
This PR aligns the `clarinet-sdk-wasm` version with the previously updated `clarinet-sdk`.