### PR TITLE
Fix SUT contract identification for same naming

### DIFF
--- a/citizen.tests.ts
+++ b/citizen.tests.ts
@@ -4,7 +4,7 @@ import {
   getContractSource,
   getSbtcBalancesFromSimnet,
   getTestContractSource,
-  groupContractsByEpochFromSimnetPlan,
+  groupContractsByEpochFromDeploymentPlan,
   issueFirstClassCitizenship,
   scheduleRendezvous,
 } from "./citizen";
@@ -20,7 +20,7 @@ import EventEmitter from "events";
 describe("Simnet deployment plan operations", () => {
   const manifestDir = "example";
   const manifestFileName = "Clarinet.toml";
-  const simnetPlanFileName = "default.simnet-plan.yaml";
+  const deploymentPlanFileName = "default.simnet-plan.yaml";
   const context = `(define-map context (string-ascii 100) {
     called: uint
     ;; other data
@@ -46,23 +46,27 @@ describe("Simnet deployment plan operations", () => {
     // Setup
     const tempDir = mkdtempSync(join(tmpdir(), "simnet-test-"));
     cpSync(manifestDir, tempDir, { recursive: true });
-    const simnetPlanPath = join(tempDir, "deployments", simnetPlanFileName);
+    const deploymentPlanPath = join(
+      tempDir,
+      "deployments",
+      deploymentPlanFileName
+    );
 
-    rmSync(simnetPlanPath, { force: true });
-    if (existsSync(simnetPlanPath)) {
-      throw new Error("Simnet plan file already exists");
+    rmSync(deploymentPlanPath, { force: true });
+    if (existsSync(deploymentPlanPath)) {
+      throw new Error("Deployment plan file already exists");
     }
 
     const manifestPath = join(tempDir, manifestFileName);
     await initSimnet(manifestPath);
 
     // Exercise
-    const simnetPlanContent = readFileSync(simnetPlanPath, {
+    const deploymentPlanContent = readFileSync(deploymentPlanPath, {
       encoding: "utf-8",
     }).toString();
 
     // Verify
-    expect(simnetPlanContent).toBeDefined();
+    expect(deploymentPlanContent).toBeDefined();
 
     // Teardown
     rmSync(tempDir, { recursive: true, force: true });
@@ -72,16 +76,21 @@ describe("Simnet deployment plan operations", () => {
     // Setup
     const tempDir = mkdtempSync(join(tmpdir(), "simnet-test-"));
     cpSync(manifestDir, tempDir, { recursive: true });
-    const simnetPlanPath = join(tempDir, "deployments", simnetPlanFileName);
+    const deploymentPlanPath = join(
+      tempDir,
+      "deployments",
+      deploymentPlanFileName
+    );
     const manifestPath = join(tempDir, manifestFileName);
 
     await initSimnet(manifestPath);
-    const parsedSimnetPlan = yaml.parse(
-      readFileSync(simnetPlanPath, { encoding: "utf-8" }).toString()
+    const parsedDeploymentPlan = yaml.parse(
+      readFileSync(deploymentPlanPath, { encoding: "utf-8" }).toString()
     );
 
     // Exercise
-    const actual = groupContractsByEpochFromSimnetPlan(parsedSimnetPlan);
+    const actual =
+      groupContractsByEpochFromDeploymentPlan(parsedDeploymentPlan);
 
     // Verify
     const expected = {
@@ -157,14 +166,22 @@ describe("Simnet deployment plan operations", () => {
     // Setup
     const tempDir = mkdtempSync(join(tmpdir(), "simnet-test-"));
     cpSync(manifestDir, tempDir, { recursive: true });
-    const simnetPlanPath = join(tempDir, "deployments", simnetPlanFileName);
+    const deploymentPlanPath = join(
+      tempDir,
+      "deployments",
+      deploymentPlanFileName
+    );
 
-    const parsedSimnetPlan = yaml.parse(
-      readFileSync(simnetPlanPath, { encoding: "utf-8" }).toString()
+    const parsedDeploymentPlan = yaml.parse(
+      readFileSync(deploymentPlanPath, { encoding: "utf-8" }).toString()
     );
 
     // Exercise
-    const actual = getTestContractSource(parsedSimnetPlan, "counter", tempDir);
+    const actual = getTestContractSource(
+      parsedDeploymentPlan,
+      "counter",
+      tempDir
+    );
 
     // Verify
     const expected = readFileSync(
@@ -182,20 +199,24 @@ describe("Simnet deployment plan operations", () => {
     // Setup
     const tempDir = mkdtempSync(join(tmpdir(), "simnet-test-"));
     cpSync(manifestDir, tempDir, { recursive: true });
-    const simnetPlanPath = join(tempDir, "deployments", simnetPlanFileName);
+    const deploymentPlanPath = join(
+      tempDir,
+      "deployments",
+      deploymentPlanFileName
+    );
     const manifestPath = join(tempDir, manifestFileName);
 
     const simnet = await initSimnet(manifestPath);
 
-    const parsedSimnetPlan = yaml.parse(
-      readFileSync(simnetPlanPath, { encoding: "utf-8" }).toString()
+    const parsedDeploymentPlan = yaml.parse(
+      readFileSync(deploymentPlanPath, { encoding: "utf-8" }).toString()
     );
 
     // Exercise
     const rendezvousSources = new Map(
       ["counter"]
         .map((contractName) =>
-          buildRendezvousData(parsedSimnetPlan, contractName, manifestDir)
+          buildRendezvousData(parsedDeploymentPlan, contractName, manifestDir)
         )
         .map((rendezvousContractData) => [
           rendezvousContractData.rendezvousContractId,
@@ -225,19 +246,23 @@ describe("Simnet deployment plan operations", () => {
     // Setup
     const tempDir = mkdtempSync(join(tmpdir(), "simnet-test-"));
     cpSync(manifestDir, tempDir, { recursive: true });
-    const simnetPlanPath = join(tempDir, "deployments", simnetPlanFileName);
+    const deploymentPlanPath = join(
+      tempDir,
+      "deployments",
+      deploymentPlanFileName
+    );
     const manifestPath = join(tempDir, manifestFileName);
 
     const simnet = await initSimnet(manifestPath);
 
-    const parsedSimnetPlan = yaml.parse(
-      readFileSync(simnetPlanPath, { encoding: "utf-8" }).toString()
+    const parsedDeploymentPlan = yaml.parse(
+      readFileSync(deploymentPlanPath, { encoding: "utf-8" }).toString()
     );
 
     const rendezvousSources = new Map(
       ["counter"]
         .map((contractName) =>
-          buildRendezvousData(parsedSimnetPlan, contractName, manifestDir)
+          buildRendezvousData(parsedDeploymentPlan, contractName, manifestDir)
         )
         .map((rendezvousContractData) => [
           rendezvousContractData.rendezvousContractId,
@@ -246,7 +271,7 @@ describe("Simnet deployment plan operations", () => {
     );
 
     const contractsByEpoch =
-      groupContractsByEpochFromSimnetPlan(parsedSimnetPlan);
+      groupContractsByEpochFromDeploymentPlan(parsedDeploymentPlan);
 
     const counterContractData = contractsByEpoch["3.0"].find(
       (contract) => contract.counter
@@ -286,19 +311,23 @@ describe("Simnet deployment plan operations", () => {
     // Setup
     const tempDir = mkdtempSync(join(tmpdir(), "simnet-test-"));
     cpSync(manifestDir, tempDir, { recursive: true });
-    const simnetPlanPath = join(tempDir, "deployments", simnetPlanFileName);
+    const deploymentPlanPath = join(
+      tempDir,
+      "deployments",
+      deploymentPlanFileName
+    );
     const manifestPath = join(tempDir, manifestFileName);
 
     const simnet = await initSimnet(manifestPath);
 
-    const parsedSimnetPlan = yaml.parse(
-      readFileSync(simnetPlanPath, { encoding: "utf-8" }).toString()
+    const parsedDeploymentPlan = yaml.parse(
+      readFileSync(deploymentPlanPath, { encoding: "utf-8" }).toString()
     );
 
     const rendezvousSources = new Map(
       ["counter"]
         .map((contractName) =>
-          buildRendezvousData(parsedSimnetPlan, contractName, manifestDir)
+          buildRendezvousData(parsedDeploymentPlan, contractName, manifestDir)
         )
         .map((rendezvousContractData) => [
           rendezvousContractData.rendezvousContractId,
@@ -307,7 +336,7 @@ describe("Simnet deployment plan operations", () => {
     );
 
     const contractsByEpoch =
-      groupContractsByEpochFromSimnetPlan(parsedSimnetPlan);
+      groupContractsByEpochFromDeploymentPlan(parsedDeploymentPlan);
 
     const cargoContractData = contractsByEpoch["3.0"].find(
       (contract) => contract.cargo

--- a/citizen.tests.ts
+++ b/citizen.tests.ts
@@ -185,7 +185,7 @@ describe("Simnet deployment plan operations", () => {
     const simnetPlanPath = join(tempDir, "deployments", simnetPlanFileName);
     const manifestPath = join(tempDir, manifestFileName);
 
-    await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
     const parsedSimnetPlan = yaml.parse(
       readFileSync(simnetPlanPath, { encoding: "utf-8" }).toString()
@@ -198,8 +198,8 @@ describe("Simnet deployment plan operations", () => {
           buildRendezvousData(parsedSimnetPlan, contractName, manifestDir)
         )
         .map((rendezvousContractData) => [
-          rendezvousContractData.rendezvousContractName,
-          rendezvousContractData.rendezvousSource,
+          rendezvousContractData.rendezvousContractId,
+          rendezvousContractData.rendezvousSourceCode,
         ])
     );
 
@@ -213,7 +213,7 @@ describe("Simnet deployment plan operations", () => {
       { encoding: "utf-8" }
     );
     const rendezvousSrc = scheduleRendezvous(counterSrc, counterTestsSrc);
-    const expected = new Map([["counter", rendezvousSrc]]);
+    const expected = new Map([[`${simnet.deployer}.counter`, rendezvousSrc]]);
 
     expect(rendezvousSources).toEqual(expected);
 
@@ -228,7 +228,7 @@ describe("Simnet deployment plan operations", () => {
     const simnetPlanPath = join(tempDir, "deployments", simnetPlanFileName);
     const manifestPath = join(tempDir, manifestFileName);
 
-    await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
     const parsedSimnetPlan = yaml.parse(
       readFileSync(simnetPlanPath, { encoding: "utf-8" }).toString()
@@ -240,8 +240,8 @@ describe("Simnet deployment plan operations", () => {
           buildRendezvousData(parsedSimnetPlan, contractName, manifestDir)
         )
         .map((rendezvousContractData) => [
-          rendezvousContractData.rendezvousContractName,
-          rendezvousContractData.rendezvousSource,
+          rendezvousContractData.rendezvousContractId,
+          rendezvousContractData.rendezvousSourceCode,
         ])
     );
 
@@ -257,6 +257,7 @@ describe("Simnet deployment plan operations", () => {
       ["counter"],
       rendezvousSources,
       "counter",
+      simnet.deployer,
       {
         path: counterContractData.path,
         clarity_version: counterContractData.clarity_version,
@@ -288,7 +289,7 @@ describe("Simnet deployment plan operations", () => {
     const simnetPlanPath = join(tempDir, "deployments", simnetPlanFileName);
     const manifestPath = join(tempDir, manifestFileName);
 
-    await initSimnet(manifestPath);
+    const simnet = await initSimnet(manifestPath);
 
     const parsedSimnetPlan = yaml.parse(
       readFileSync(simnetPlanPath, { encoding: "utf-8" }).toString()
@@ -300,8 +301,8 @@ describe("Simnet deployment plan operations", () => {
           buildRendezvousData(parsedSimnetPlan, contractName, manifestDir)
         )
         .map((rendezvousContractData) => [
-          rendezvousContractData.rendezvousContractName,
-          rendezvousContractData.rendezvousSource,
+          rendezvousContractData.rendezvousContractId,
+          rendezvousContractData.rendezvousSourceCode,
         ])
     );
 
@@ -317,6 +318,7 @@ describe("Simnet deployment plan operations", () => {
       ["counter"],
       rendezvousSources,
       "cargo",
+      simnet.deployer,
       {
         path: cargoContractData.path,
         clarity_version: cargoContractData.clarity_version,

--- a/citizen.ts
+++ b/citizen.ts
@@ -94,7 +94,9 @@ export const issueFirstClassCitizenship = async (
       ])
   );
 
-  const clarinetToml = parseClarintConfig(manifestPath);
+  const clarinetToml = toml.parse(
+    readFileSync(manifestPath, { encoding: "utf-8" })
+  ) as any;
   const cacheDir = clarinetToml.project?.cache_dir || "./.cache";
 
   // Deploy the contracts to the empty simnet session in the correct order.
@@ -648,12 +650,4 @@ const getUniqueHex = (): string => {
     .join("");
 
   return hex;
-};
-
-/**
- * Parses the Clarinet.toml file to extract configuration.
- */
-const parseClarintConfig = (manifestPath: string) => {
-  const clarintTomlContent = readFileSync(manifestPath, { encoding: "utf-8" });
-  return toml.parse(clarintTomlContent) as any;
 };

--- a/citizen.types.ts
+++ b/citizen.types.ts
@@ -11,7 +11,7 @@ type Genesis = {
   contracts: string[];
 };
 
-type EmulatedContractPublish = {
+export type EmulatedContractPublish = {
   "contract-name": string;
   "emulated-sender": string;
   path: string;

--- a/citizen.types.ts
+++ b/citizen.types.ts
@@ -32,7 +32,7 @@ type Plan = {
   batches: Batch[];
 };
 
-export type SimnetPlan = {
+export type DeploymentPlan = {
   id: number;
   name: string;
   network: string;


### PR DESCRIPTION
This PR allows Rendezvous to prioritize the project contract over the requirement one when both are named the same. If two requirements have the contract name used as target contract name and no project contract matches, Rendezvous will throw an error.

Resolves #150.