### PR TITLE
Report run statistics

### DIFF
--- a/heatstroke.tests.ts
+++ b/heatstroke.tests.ts
@@ -102,7 +102,7 @@ describe("Custom reporter logging", () => {
           };
 
           // Act
-          reporter(runDetails, radio, "invariant");
+          reporter(runDetails, radio, "invariant", {});
 
           // Assert
           const expectedMessages = [
@@ -248,7 +248,7 @@ describe("Custom reporter logging", () => {
           };
 
           // Act
-          reporter(runDetails, radio, "invariant");
+          reporter(runDetails, radio, "invariant", {});
 
           // Assert
           const expectedMessages = [
@@ -396,7 +396,7 @@ describe("Custom reporter logging", () => {
           };
 
           // Act
-          reporter(runDetails, radio, "invariant");
+          reporter(runDetails, radio, "invariant", {});
 
           // Assert
           expect(emittedErrorLogs).toEqual([]);
@@ -472,7 +472,7 @@ describe("Custom reporter logging", () => {
           };
 
           // Act
-          reporter(runDetails, radio, "test");
+          reporter(runDetails, radio, "test", {});
 
           // Assert
           const expectedMessages = [
@@ -573,7 +573,7 @@ describe("Custom reporter logging", () => {
           };
 
           // Act
-          reporter(runDetails, radio, "test");
+          reporter(runDetails, radio, "test", {});
 
           // Assert
           const expectedMessages = [
@@ -672,7 +672,7 @@ describe("Custom reporter logging", () => {
           };
 
           // Act
-          reporter(runDetails, radio, "test");
+          reporter(runDetails, radio, "test", {});
 
           // Assert
 

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -206,17 +206,17 @@ function reportStatistics(
       logAsTree(Object.fromEntries(statistics.sut.successful), radio);
 
       radio.emit("logMessage", "│");
-      radio.emit("logMessage", `├─ ${FAIL_SYMBOL} FAILED (IGNORED)`);
+      radio.emit("logMessage", `├─ ${FAIL_SYMBOL} IGNORED`);
       logAsTree(Object.fromEntries(statistics.sut.failed), radio);
 
       radio.emit("logMessage", "│");
-      radio.emit("logMessage", "│ INVARIANT VALIDATION CALLS");
+      radio.emit("logMessage", "│ INVARIANT CHECKS");
       radio.emit("logMessage", "│");
-      radio.emit("logMessage", `├─ ${SUCCESS_SYMBOL} VALIDATED`);
+      radio.emit("logMessage", `├─ ${SUCCESS_SYMBOL} PASSED`);
       logAsTree(Object.fromEntries(statistics.invariant.successful), radio);
 
       radio.emit("logMessage", "│");
-      radio.emit("logMessage", `└─ ${FAIL_SYMBOL} FALSIFIED`);
+      radio.emit("logMessage", `└─ ${FAIL_SYMBOL} FAILED`);
       logAsTree(Object.fromEntries(statistics.invariant.failed), radio, {
         isLastSection: true,
       });
@@ -234,7 +234,7 @@ function reportStatistics(
 
       radio.emit("logMessage", "│ PROPERTY TEST CALLS");
       radio.emit("logMessage", "│");
-      radio.emit("logMessage", `├─ ${SUCCESS_SYMBOL} VALIDATED`);
+      radio.emit("logMessage", `├─ ${SUCCESS_SYMBOL} PASSED`);
       logAsTree(Object.fromEntries(statistics.test.successful), radio);
 
       radio.emit("logMessage", "│");

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -227,19 +227,19 @@ function reportStatistics(
       radio.emit("logMessage", "\nLEGEND:");
       radio.emit(
         "logMessage",
-        "   • SUCCESSFUL calls executed without errors and advanced the test"
+        "   • SUCCESSFUL calls executed without errors and advanced the test."
       );
       radio.emit(
         "logMessage",
-        "   • IGNORED calls failed execution but did not affect the test"
+        "   • IGNORED calls failed execution but did not affect the test."
       );
       radio.emit(
         "logMessage",
-        "   • PASSED invariants maintained system integrity"
+        "   • PASSED invariants maintained system integrity."
       );
       radio.emit(
         "logMessage",
-        "   • FAILED invariants indicate potential contract vulnerabilities"
+        "   • FAILED invariants indicate potential contract vulnerabilities."
       );
       if (computeTotalCount(statistics.invariant!.failed) > 0) {
         radio.emit(
@@ -269,15 +269,15 @@ function reportStatistics(
       radio.emit("logMessage", "\nLEGEND:");
       radio.emit(
         "logMessage",
-        "   • PASSED tests verify that properties hold for the given inputs"
+        "   • PASSED tests verify that properties hold for the given inputs."
       );
       radio.emit(
         "logMessage",
-        "   • DISCARDED tests were skipped due to invalid preconditions"
+        "   • DISCARDED tests were skipped due to invalid preconditions."
       );
       radio.emit(
         "logMessage",
-        "   • FAILED tests indicate property violations or unexpected behavior"
+        "   • FAILED tests indicate property violations or unexpected behavior."
       );
       if (computeTotalCount(statistics.test!.failed) > 0) {
         radio.emit(

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -203,11 +203,6 @@ function reportStatistics(
 
   switch (type) {
     case "invariant": {
-      radio.emit(
-        "logMessage",
-        "The following statistics show the execution results from invariant testing, where random sequences of function calls are generated to verify that system-wide general truths (invariants) remain true regardless of operation order.\n"
-      );
-
       radio.emit("logMessage", "│ PUBLIC FUNCTION CALLS");
       radio.emit("logMessage", "│");
       radio.emit("logMessage", `├─ ${SUCCESS_SYMBOL} SUCCESSFUL`);
@@ -256,11 +251,6 @@ function reportStatistics(
     }
 
     case "test": {
-      radio.emit(
-        "logMessage",
-        "The following statistics show the execution results from property-based testing, where random inputs are generated for property test functions to verify that specific properties hold true across a wide range of test scenarios.\n"
-      );
-
       radio.emit("logMessage", "│ PROPERTY TEST CALLS");
       radio.emit("logMessage", "│");
       radio.emit("logMessage", `├─ ${SUCCESS_SYMBOL} PASSED`);

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -224,22 +224,22 @@ function reportStatistics(
         isLastSection: true,
       });
 
-      radio.emit("logMessage", "\nLEGEND:");
+      radio.emit("logMessage", "\nLEGEND:\n");
       radio.emit(
         "logMessage",
-        "   • SUCCESSFUL calls executed without errors and advanced the test."
+        "  SUCCESSFUL calls executed and advanced the test"
       );
       radio.emit(
         "logMessage",
-        "   • IGNORED calls failed execution but did not affect the test."
+        "  IGNORED    calls failed but did not affect the test"
       );
       radio.emit(
         "logMessage",
-        "   • PASSED invariants maintained system integrity."
+        "  PASSED     invariants maintained system integrity"
       );
       radio.emit(
         "logMessage",
-        "   • FAILED invariants indicate potential contract vulnerabilities."
+        "  FAILED     invariants indicate contract vulnerabilities"
       );
       if (computeTotalCount(statistics.invariant!.failed) > 0) {
         radio.emit(
@@ -266,18 +266,18 @@ function reportStatistics(
         isLastSection: true,
       });
 
-      radio.emit("logMessage", "\nLEGEND:");
+      radio.emit("logMessage", "\nLEGEND:\n");
       radio.emit(
         "logMessage",
-        "   • PASSED tests verify that properties hold for the given inputs."
+        "  PASSED    properties verified for given inputs"
       );
       radio.emit(
         "logMessage",
-        "   • DISCARDED tests were skipped due to invalid preconditions."
+        "  DISCARDED skipped due to invalid preconditions"
       );
       radio.emit(
         "logMessage",
-        "   • FAILED tests indicate property violations or unexpected behavior."
+        "  FAILED    property violations or unexpected behavior"
       );
       if (computeTotalCount(statistics.test!.failed) > 0) {
         radio.emit(

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -5,8 +5,8 @@ import {
   InvariantCounterExample,
   RunDetails,
   Statistics,
-  TestCounterExample,
   StatisticsTreeOptions,
+  TestCounterExample,
 } from "./heatstroke.types";
 import { getContractNameFromContractId } from "./shared";
 
@@ -175,11 +175,10 @@ export function reporter(
   radio.emit("logMessage", "\n");
 }
 
-const ARROW = "▶";
-const LIGHTNING = "⚡";
-const SUCCESS_SYMBOL = "✓";
-const FAIL_SYMBOL = "✗";
-const WARN_SYMBOL = "⚠";
+const ARROW = "->";
+const SUCCESS_SYMBOL = "+";
+const FAIL_SYMBOL = "-";
+const WARN_SYMBOL = "!";
 
 /**
  * Reports execution statistics in a tree-like format.
@@ -192,15 +191,12 @@ function reportStatistics(
   type: "invariant" | "test",
   radio: EventEmitter
 ): void {
-  radio.emit("logMessage", `\nEXECUTION STATISTICS ${LIGHTNING}\n`);
+  radio.emit("logMessage", `\nEXECUTION STATISTICS\n`);
 
   switch (type) {
     case "invariant": {
       if (!statistics.invariant || !statistics.sut) {
-        radio.emit(
-          "logMessage",
-          "└─ No telemetry data available for this operation"
-        );
+        radio.emit("logMessage", "└─ No statistics available for this run");
         return;
       }
 

--- a/heatstroke.types.ts
+++ b/heatstroke.types.ts
@@ -27,3 +27,25 @@ export type InvariantCounterExample = {
   invariantArgs: any;
   invariantCaller: [string, string];
 };
+
+type SutFunctionStatistics = {
+  successful: Map<string, number>;
+  failed: Map<string, number>;
+};
+
+type InvariantFunctionStatistics = {
+  successful: Map<string, number>;
+  failed: Map<string, number>;
+};
+
+type TestFunctionStatistics = {
+  successful: Map<string, number>;
+  discarded: Map<string, number>;
+  failed: Map<string, number>;
+};
+
+export type Statistics = {
+  sut?: SutFunctionStatistics;
+  invariant?: InvariantFunctionStatistics;
+  test?: TestFunctionStatistics;
+};

--- a/heatstroke.types.ts
+++ b/heatstroke.types.ts
@@ -49,3 +49,11 @@ export type Statistics = {
   invariant?: InvariantFunctionStatistics;
   test?: TestFunctionStatistics;
 };
+
+/**
+ * Options for configuring tree statistics reporting.
+ */
+export interface StatisticsTreeOptions {
+  isLastSection?: boolean;
+  baseIndent?: string;
+}

--- a/invariant.ts
+++ b/invariant.ts
@@ -62,11 +62,15 @@ export const checkInvariants = async (
   // to access the SUT functions for each Rendezvous contract afterwards.
   const rendezvousSutFunctions = filterSutFunctions(rendezvousAllFunctions);
 
-  for (const fns of rendezvousSutFunctions.values()) {
-    for (const fn of fns) {
-      statistics.sut!.successful.set(fn.name, 0);
-      statistics.sut!.failed.set(fn.name, 0);
-    }
+  // The Rendezvous identifier is the first one in the list. Only one contract
+  // can be fuzzed at a time.
+  const rendezvousContractId = rendezvousList[0];
+
+  for (const functionInterface of rendezvousSutFunctions.get(
+    rendezvousContractId
+  )!) {
+    statistics.sut!.successful.set(functionInterface.name, 0);
+    statistics.sut!.failed.set(functionInterface.name, 0);
   }
 
   // A map where the keys are the Rendezvous identifiers and the values are
@@ -76,16 +80,12 @@ export const checkInvariants = async (
     rendezvousAllFunctions
   );
 
-  for (const fns of rendezvousInvariantFunctions.values()) {
-    for (const fn of fns) {
-      statistics.invariant!.successful.set(fn.name, 0);
-      statistics.invariant!.failed.set(fn.name, 0);
-    }
+  for (const functionInterface of rendezvousInvariantFunctions.get(
+    rendezvousContractId
+  )!) {
+    statistics.invariant!.successful.set(functionInterface.name, 0);
+    statistics.invariant!.failed.set(functionInterface.name, 0);
   }
-
-  // The Rendezvous identifier is the first one in the list. Only one contract
-  // can be fuzzed at a time.
-  const rendezvousContractId = rendezvousList[0];
 
   const traitReferenceSutFunctions = rendezvousSutFunctions
     .get(rendezvousContractId)!

--- a/property.ts
+++ b/property.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "events";
 import fc from "fast-check";
 import { cvToJSON, cvToString } from "@stacks/transactions";
 import { reporter } from "./heatstroke";
+import { Statistics } from "./heatstroke.types";
 import {
   argsToCV,
   functionToArbitrary,
@@ -42,6 +43,13 @@ export const checkProperties = (
   runs: number | undefined,
   radio: EventEmitter
 ) => {
+  const statistics: Statistics = {
+    test: {
+      successful: new Map<string, number>(),
+      discarded: new Map<string, number>(),
+      failed: new Map<string, number>(),
+    },
+  };
   const testContractId = rendezvousList[0];
 
   // A map where the keys are the test contract identifiers and the values are
@@ -50,6 +58,14 @@ export const checkProperties = (
   const testContractsTestFunctions = filterTestFunctions(
     rendezvousAllFunctions
   );
+
+  for (const functionInterface of testContractsTestFunctions.get(
+    testContractId
+  )!) {
+    statistics.test!.successful.set(functionInterface.name, 0);
+    statistics.test!.discarded.set(functionInterface.name, 0);
+    statistics.test!.failed.set(functionInterface.name, 0);
+  }
 
   const traitReferenceFunctions = testContractsTestFunctions
     .get(testContractId)!
@@ -163,7 +179,7 @@ export const checkProperties = (
   }
 
   const radioReporter = (runDetails: any) => {
-    reporter(runDetails, radio, "test");
+    reporter(runDetails, radio, "test", statistics);
   };
 
   fc.assert(
@@ -248,6 +264,10 @@ export const checkProperties = (
         );
 
         if (discarded) {
+          statistics.test!.discarded.set(
+            r.selectedTestFunction.name,
+            statistics.test!.discarded.get(r.selectedTestFunction.name)! + 1
+          );
           radio.emit(
             "logMessage",
             `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
@@ -280,6 +300,10 @@ export const checkProperties = (
             );
 
             if (discardedInPlace) {
+              statistics.test!.discarded.set(
+                r.selectedTestFunction.name,
+                statistics.test!.discarded.get(r.selectedTestFunction.name)! + 1
+              );
               radio.emit(
                 "logMessage",
                 `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
@@ -296,6 +320,11 @@ export const checkProperties = (
               testFunctionCallResultJson.success &&
               testFunctionCallResultJson.value.value === true
             ) {
+              statistics.test!.successful.set(
+                r.selectedTestFunction.name,
+                statistics.test!.successful.get(r.selectedTestFunction.name)! +
+                  1
+              );
               radio.emit(
                 "logMessage",
                 `₿ ${simnet.burnBlockHeight.toString().padStart(8)} ` +
@@ -312,6 +341,10 @@ export const checkProperties = (
                 simnet.mineEmptyBurnBlocks(r.burnBlocks);
               }
             } else {
+              statistics.test!.failed.set(
+                r.selectedTestFunction.name,
+                statistics.test!.failed.get(r.selectedTestFunction.name)! + 1
+              );
               // The function call did not result in (ok true) or (ok false).
               // Either the test failed or the test function returned an
               // unexpected value i.e. `(ok 1)`.


### PR DESCRIPTION
This PR adds run statistics that are reported when the fuzzing finishes. Before this, users had to dig through a lot of logs just to figure out what happened during their Rendezvous fuzzing run. Now they get the key insights upfront, and diving into the full logs is optional - though still pretty useful if they want to see exactly how the contract behaved during the invariant/property testing run. This applies to both successful/failed runs.

Resolves #162.