### PR TITLE
Add fail-fast option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ npx rv <path-to-clarinet-project> <contract-name> <type>
 - `--path` – The path to use for the replay functionality.
 - `--runs` – The number of test iterations to use for exercising the contracts.
   (default: `100`)
+- `--bail` – Stop after the first failure.
 - `--dial` – The path to a JavaScript file containing custom pre- and
   post-execution functions (dialers).
 

--- a/app.tests.ts
+++ b/app.tests.ts
@@ -150,6 +150,16 @@ describe("Command-line arguments handling", () => {
       ],
     ],
     [
+      ["manifest path", "contract name", "seed", "bail"],
+      ["node", "app.js", "example", "counter", "--bail"],
+      [
+        red(
+          `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`
+        ),
+        helpMessage,
+      ],
+    ],
+    [
       ["manifest path", "contract name", "seed"],
       ["node", "app.js", "example", "counter", "--seed=123"],
       [
@@ -226,6 +236,16 @@ describe("Command-line arguments handling", () => {
       ],
     ],
     [
+      ["manifest path", "contract name", "type=invariant", "bail"],
+      ["node", "app.js", "example", "counter", "invariant", "--bail"],
+      [
+        `Using manifest path: example/Clarinet.toml`,
+        `Target contract: counter`,
+        `Bailing on first failure.`,
+        `\nStarting invariant testing type for the counter contract...\n`,
+      ],
+    ],
+    [
       ["manifest path", "contract name", "type=invariant", "dialers file path"],
       [
         "node",
@@ -257,6 +277,16 @@ describe("Command-line arguments handling", () => {
       [
         `Using manifest path: example/Clarinet.toml`,
         `Target contract: counter`,
+        `\nStarting property testing type for the counter contract...\n`,
+      ],
+    ],
+    [
+      ["manifest path", "contract name", "type=test", "bail"],
+      ["node", "app.js", "example", "counter", "test", "--bail"],
+      [
+        `Using manifest path: example/Clarinet.toml`,
+        `Target contract: counter`,
+        `Bailing on first failure.`,
         `\nStarting property testing type for the counter contract...\n`,
       ],
     ],
@@ -384,6 +414,68 @@ describe("Command-line arguments handling", () => {
         `Using seed: 123`,
         `Using path: 84:0`,
         `\nStarting property testing type for the counter contract...\n`,
+      ],
+    ],
+    [
+      [
+        "manifest path",
+        "contract name",
+        "type=test",
+        "seed",
+        "path",
+        "runs",
+        "bail",
+      ],
+      [
+        "node",
+        "app.js",
+        "example",
+        "counter",
+        "test",
+        "--seed=123",
+        "--path=84:0",
+        "--runs=10",
+        "--bail",
+      ],
+      [
+        `Using manifest path: example/Clarinet.toml`,
+        `Target contract: counter`,
+        `Using seed: 123`,
+        `Using path: 84:0`,
+        `Using runs: 10`,
+        `Bailing on first failure.`,
+        `\nStarting property testing type for the counter contract...\n`,
+      ],
+    ],
+    [
+      [
+        "manifest path",
+        "contract name",
+        "type=invariant",
+        "seed",
+        "path",
+        "runs",
+        "bail",
+      ],
+      [
+        "node",
+        "app.js",
+        "example",
+        "counter",
+        "invariant",
+        "--seed=123",
+        "--path=84:0",
+        "--runs=10",
+        "--bail",
+      ],
+      [
+        `Using manifest path: example/Clarinet.toml`,
+        `Target contract: counter`,
+        `Using seed: 123`,
+        `Using path: 84:0`,
+        `Using runs: 10`,
+        `Bailing on first failure.`,
+        `\nStarting invariant testing type for the counter contract...\n`,
       ],
     ],
   ])(

--- a/app.tests.ts
+++ b/app.tests.ts
@@ -66,6 +66,7 @@ describe("Command-line arguments handling", () => {
     --seed - The seed to use for the replay functionality.
     --path - The path to use for the replay functionality.
     --runs - The runs to use for iterating over the tests. Default: 100.
+    --bail - Stop after the first failure.
     --dial – The path to a JavaScript file containing custom pre- and post-execution functions (dialers).
     --help - Show the help message.
   `;

--- a/app.tests.ts
+++ b/app.tests.ts
@@ -1,13 +1,13 @@
 import { red, yellow } from "ansicolor";
 import {
   getManifestFileName,
+  helpMessage,
   invalidRemoteDataWarningMessage,
   main,
   noRemoteData,
   tryParseRemoteDataSettings,
 } from "./app";
 import { RemoteDataSettings } from "./app.types";
-import { version } from "./package.json";
 import { resolve } from "path";
 import fs from "fs";
 import EventEmitter from "events";
@@ -52,24 +52,6 @@ initial_height = 595012
 describe("Command-line arguments handling", () => {
   const initialArgv = process.argv;
 
-  const helpMessage = `
-  rv v${version}
-  
-  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>] [--dial=<path-to-dialers-file>] [--help]
-
-  Positional arguments:
-    path-to-clarinet-project - The path to the Clarinet project.
-    contract-name - The name of the contract to be fuzzed.
-    type - The type to use for exercising the contracts. Possible values: test, invariant.
-
-  Options:
-    --seed - The seed to use for the replay functionality.
-    --path - The path to use for the replay functionality.
-    --runs - The runs to use for iterating over the tests. Default: 100.
-    --bail - Stop after the first failure.
-    --dial – The path to a JavaScript file containing custom pre- and post-execution functions (dialers).
-    --help - Show the help message.
-  `;
   const noManifestMessage = red(
     `\nNo path to Clarinet project provided. Supply it immediately or face the relentless scrutiny of your contract's vulnerabilities.`
   );

--- a/app.tests.ts
+++ b/app.tests.ts
@@ -1,13 +1,13 @@
 import { red, yellow } from "ansicolor";
 import {
   getManifestFileName,
-  helpMessage,
   invalidRemoteDataWarningMessage,
   main,
   noRemoteData,
   tryParseRemoteDataSettings,
 } from "./app";
 import { RemoteDataSettings } from "./app.types";
+import { version } from "./package.json";
 import { resolve } from "path";
 import fs from "fs";
 import EventEmitter from "events";
@@ -51,6 +51,25 @@ initial_height = 595012
 
 describe("Command-line arguments handling", () => {
   const initialArgv = process.argv;
+
+  const helpMessage = `
+  rv v${version}
+  
+  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>] [--dial=<path-to-dialers-file>] [--help]
+
+  Positional arguments:
+    path-to-clarinet-project - The path to the Clarinet project.
+    contract-name - The name of the contract to be fuzzed.
+    type - The type to use for exercising the contracts. Possible values: test, invariant.
+
+  Options:
+    --seed - The seed to use for the replay functionality.
+    --path - The path to use for the replay functionality.
+    --runs - The runs to use for iterating over the tests. Default: 100.
+    --bail - Stop after the first failure.
+    --dial – The path to a JavaScript file containing custom pre- and post-execution functions (dialers).
+    --help - Show the help message.
+  `;
 
   const noManifestMessage = red(
     `\nNo path to Clarinet project provided. Supply it immediately or face the relentless scrutiny of your contract's vulnerabilities.`

--- a/app.ts
+++ b/app.ts
@@ -106,9 +106,13 @@ const helpMessage = `
     --seed - The seed to use for the replay functionality.
     --path - The path to use for the replay functionality.
     --runs - The runs to use for iterating over the tests. Default: 100.
+    --bail - Stop after the first failure.
     --dial – The path to a JavaScript file containing custom pre- and post-execution functions (dialers).
     --help - Show the help message.
   `;
+
+const parseBooleanOption = (argName: string): boolean =>
+  process.argv.slice(4).includes(`--${argName}`);
 
 const parseOptionalArgument = (argName: string) => {
   return process.argv
@@ -193,6 +197,11 @@ export async function main() {
     radio.emit("logMessage", `Using runs: ${runs}`);
   }
 
+  const endOnFailure = parseBooleanOption("bail");
+  if (endOnFailure) {
+    radio.emit("logMessage", `Bailing on first failure.`);
+  }
+
   /**
    * The path to the dialer file. The dialer file allows the user to register
    * custom pre and post-execution JavaScript functions to be executed before
@@ -254,6 +263,7 @@ export async function main() {
         seed,
         path,
         runs,
+        endOnFailure,
         dialerRegistry,
         radio
       );
@@ -269,6 +279,7 @@ export async function main() {
         seed,
         path,
         runs,
+        endOnFailure,
         radio
       );
       break;

--- a/app.ts
+++ b/app.ts
@@ -92,7 +92,7 @@ export const tryParseRemoteDataSettings = (
   return remoteDataUserSettings;
 };
 
-export const helpMessage = `
+const helpMessage = `
   rv v${version}
   
   Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>] [--dial=<path-to-dialers-file>] [--help]

--- a/app.ts
+++ b/app.ts
@@ -114,7 +114,7 @@ export const helpMessage = `
 const parseBooleanOption = (argName: string): boolean =>
   process.argv.slice(4).includes(`--${argName}`);
 
-const parseOptionalArgument = (argName: string) => {
+const parseOption = (argName: string) => {
   return process.argv
     .find(
       (arg, idx) => idx >= 4 && arg.toLowerCase().startsWith(`--${argName}`)
@@ -182,17 +182,17 @@ export async function main() {
   radio.emit("logMessage", `Using manifest path: ${manifestPath}`);
   radio.emit("logMessage", `Target contract: ${sutContractName}`);
 
-  const seed = parseInt(parseOptionalArgument("seed")!, 10) || undefined;
+  const seed = parseInt(parseOption("seed")!, 10) || undefined;
   if (seed !== undefined) {
     radio.emit("logMessage", `Using seed: ${seed}`);
   }
 
-  const path = parseOptionalArgument("path") || undefined;
+  const path = parseOption("path") || undefined;
   if (path !== undefined) {
     radio.emit("logMessage", `Using path: ${path}`);
   }
 
-  const runs = parseInt(parseOptionalArgument("runs")!, 10) || undefined;
+  const runs = parseInt(parseOption("runs")!, 10) || undefined;
   if (runs !== undefined) {
     radio.emit("logMessage", `Using runs: ${runs}`);
   }
@@ -207,7 +207,7 @@ export async function main() {
    * custom pre and post-execution JavaScript functions to be executed before
    * and after the public function calls during invariant testing.
    */
-  const dialPath = parseOptionalArgument("dial") || undefined;
+  const dialPath = parseOption("dial") || undefined;
   if (dialPath !== undefined) {
     radio.emit("logMessage", `Using dial path: ${dialPath}`);
   }

--- a/app.ts
+++ b/app.ts
@@ -92,7 +92,7 @@ export const tryParseRemoteDataSettings = (
   return remoteDataUserSettings;
 };
 
-const helpMessage = `
+export const helpMessage = `
   rv v${version}
   
   Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>] [--dial=<path-to-dialers-file>] [--help]

--- a/app.ts
+++ b/app.ts
@@ -197,8 +197,8 @@ export async function main() {
     radio.emit("logMessage", `Using runs: ${runs}`);
   }
 
-  const endOnFailure = parseBooleanOption("bail");
-  if (endOnFailure) {
+  const bail = parseBooleanOption("bail");
+  if (bail) {
     radio.emit("logMessage", `Bailing on first failure.`);
   }
 
@@ -263,7 +263,7 @@ export async function main() {
         seed,
         path,
         runs,
-        endOnFailure,
+        bail,
         dialerRegistry,
         radio
       );
@@ -279,7 +279,7 @@ export async function main() {
         seed,
         path,
         runs,
-        endOnFailure,
+        bail,
         radio
       );
       break;

--- a/docs/chapter_6.md
+++ b/docs/chapter_6.md
@@ -34,7 +34,7 @@ This chapter explains how to use Rendezvous in different situations. By the end,
 To run Rendezvous, use the following command:
 
 ```bash
-rv <path-to-clarinet-project> <contract-name> <type> [--seed] [--runs] [--dial]
+rv <path-to-clarinet-project> <contract-name> <type> [--seed] [--runs] [--bail] [--dial]
 ```
 
 Let's break down each part of the command.
@@ -172,7 +172,17 @@ In this case, the seed is `426141810`. You can use it to rerun the exact same te
 rv root contract test --seed=426141810
 ```
 
-**3. Using Dialers**
+**3. Stop After First Failure**
+
+By default, Rendezvous will start the shrinking process after finding a failure. To stop immediately when the first failure is detected, use the `--bail` option:
+
+```bash
+rv root contract test --bail
+```
+
+This is useful when you want to examine the first failure without waiting for the complete test run and shrinking process to finish.
+
+**4. Using Dialers**
 
 Dialers allow you to define **pre- and post-execution functions** using JavaScript **during invariant testing**. To use a custom dialer file, run:
 

--- a/invariant.ts
+++ b/invariant.ts
@@ -31,6 +31,7 @@ import { DialerRegistry, PostDialerError, PreDialerError } from "./dialer";
  * @param seed The seed for reproducible invariant testing.
  * @param path The path for reproducible invariant testing.
  * @param runs The number of test runs.
+ * @param endOnFailure Whether to stop fuzzing after the first failure.
  * @param dialerRegistry The custom dialer registry.
  * @param radio The custom logging event emitter.
  * @returns void
@@ -43,6 +44,7 @@ export const checkInvariants = async (
   seed: number | undefined,
   path: string | undefined,
   runs: number | undefined,
+  endOnFailure: boolean,
   dialerRegistry: DialerRegistry | undefined,
   radio: EventEmitter
 ) => {
@@ -479,6 +481,7 @@ export const checkInvariants = async (
       seed: seed,
       path: path,
       numRuns: runs,
+      endOnFailure: endOnFailure,
     }
   );
 };

--- a/invariant.ts
+++ b/invariant.ts
@@ -476,12 +476,12 @@ export const checkInvariants = async (
       }
     ),
     {
-      verbose: true,
+      endOnFailure: endOnFailure,
+      numRuns: runs,
+      path: path,
       reporter: radioReporter,
       seed: seed,
-      path: path,
-      numRuns: runs,
-      endOnFailure: endOnFailure,
+      verbose: true,
     }
   );
 };

--- a/invariant.ts
+++ b/invariant.ts
@@ -31,7 +31,8 @@ import { DialerRegistry, PostDialerError, PreDialerError } from "./dialer";
  * @param seed The seed for reproducible invariant testing.
  * @param path The path for reproducible invariant testing.
  * @param runs The number of test runs.
- * @param endOnFailure Whether to stop fuzzing after the first failure.
+ * @param bail Stop execution after the first failure and prevent further
+ * shrinking.
  * @param dialerRegistry The custom dialer registry.
  * @param radio The custom logging event emitter.
  * @returns void
@@ -44,7 +45,7 @@ export const checkInvariants = async (
   seed: number | undefined,
   path: string | undefined,
   runs: number | undefined,
-  endOnFailure: boolean,
+  bail: boolean,
   dialerRegistry: DialerRegistry | undefined,
   radio: EventEmitter
 ) => {
@@ -476,7 +477,7 @@ export const checkInvariants = async (
       }
     ),
     {
-      endOnFailure: endOnFailure,
+      endOnFailure: bail,
       numRuns: runs,
       path: path,
       reporter: radioReporter,

--- a/property.ts
+++ b/property.ts
@@ -29,7 +29,8 @@ import {
  * @param seed The seed for reproducible property-based tests.
  * @param path The path for reproducible property-based tests.
  * @param runs The number of test runs.
- * @param endOnFailure Whether to stop fuzzing after the first failure.
+ * @param bail Stop execution after the first failure and prevent further
+ * shrinking.
  * @param radio The custom logging event emitter.
  * @returns void
  */
@@ -41,7 +42,7 @@ export const checkProperties = (
   seed: number | undefined,
   path: string | undefined,
   runs: number | undefined,
-  endOnFailure: boolean,
+  bail: boolean,
   radio: EventEmitter
 ) => {
   const testContractId = rendezvousList[0];
@@ -354,7 +355,7 @@ export const checkProperties = (
       }
     ),
     {
-      endOnFailure: endOnFailure,
+      endOnFailure: bail,
       numRuns: runs,
       path: path,
       reporter: radioReporter,

--- a/property.ts
+++ b/property.ts
@@ -354,12 +354,12 @@ export const checkProperties = (
       }
     ),
     {
-      verbose: true,
+      endOnFailure: endOnFailure,
+      numRuns: runs,
+      path: path,
       reporter: radioReporter,
       seed: seed,
-      path: path,
-      numRuns: runs,
-      endOnFailure: endOnFailure,
+      verbose: true,
     }
   );
 };

--- a/property.ts
+++ b/property.ts
@@ -29,6 +29,7 @@ import {
  * @param seed The seed for reproducible property-based tests.
  * @param path The path for reproducible property-based tests.
  * @param runs The number of test runs.
+ * @param endOnFailure Whether to stop fuzzing after the first failure.
  * @param radio The custom logging event emitter.
  * @returns void
  */
@@ -40,6 +41,7 @@ export const checkProperties = (
   seed: number | undefined,
   path: string | undefined,
   runs: number | undefined,
+  endOnFailure: boolean,
   radio: EventEmitter
 ) => {
   const testContractId = rendezvousList[0];
@@ -357,6 +359,7 @@ export const checkProperties = (
       seed: seed,
       path: path,
       numRuns: runs,
+      endOnFailure: endOnFailure,
     }
   );
 };


### PR DESCRIPTION
This PR adds a fail-fast flag (`--bail`) so users can stop fuzzing as soon as something breaks instead of going through the rest of the run and shrinking.

Resolves #161.