### PR TITLE
Automate example project updates after npm release

### DIFF
--- a/.github/workflows/npm-publish-release.yml
+++ b/.github/workflows/npm-publish-release.yml
@@ -23,3 +23,79 @@ jobs:
       - run: npm test
       - run: npm run build
       - run: npm publish
+
+  update-example-post-release:
+    needs: publish
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.ref_name }}
+      BRANCH_NAME: post-release/update-example
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Wait for npm propagation
+        run: sleep 30
+
+      - name: Verify version availability on npm with retries
+        run: |
+          echo "Checking if @stacks/rendezvous@$VERSION is available on npm..."
+
+          # Retry up to 5 times with 10 second intervals.
+          for i in {1..5}; do
+            if npm view @stacks/rendezvous@$VERSION version >/dev/null 2>&1; then
+              echo "Package @stacks/rendezvous@$VERSION is available on npm"
+              break
+            else
+              echo "Attempt $i: Package not yet available, waiting 10 seconds..."
+              if [ $i -eq 5 ]; then
+                echo "Package @stacks/rendezvous@$VERSION not found after 5 attempts"
+                exit 1
+              fi
+              sleep 10
+            fi
+          done
+
+      - name: Update example project to use published version
+        run: |
+          echo "Updating example project to use version: $VERSION"
+
+          # Configure git.
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+
+          # Create and checkout post-release branch.
+          git checkout -b "$BRANCH_NAME"
+
+          # Update example to use the published version.
+          cd example
+          npm install @stacks/rendezvous@$VERSION
+          cd ..
+
+          # Add the updated package.json and package-lock.json.
+          git add example/package.json
+          git add example/package-lock.json
+
+          # Commit the changes.
+          git commit -m "Update example project to use @stacks/rendezvous@$VERSION"
+
+          # Push the branch.
+          git push origin "$BRANCH_NAME"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.BRANCH_NAME }}
+          title: "Update example project to use @stacks/rendezvous@${{ env.VERSION }}"
+          body: |
+            This post-release PR updates the `example` Clarinet project to use the latest Rendezvous version.
+
+            **Changes:**
+            - Updates `@stacks/rendezvous` dependency to `${{ env.VERSION }}`
+
+            Auto-generated after release ${{ env.VERSION }}.
+          base: master

--- a/.github/workflows/npm-publish-release.yml
+++ b/.github/workflows/npm-publish-release.yml
@@ -5,7 +5,8 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   publish:
@@ -62,40 +63,23 @@ jobs:
       - name: Update example project to use published version
         run: |
           echo "Updating example project to use version: $VERSION"
-
-          # Configure git.
-          git config user.email "action@github.com"
-          git config user.name "GitHub Action"
-
-          # Create and checkout post-release branch.
-          git checkout -b "$BRANCH_NAME"
-
           # Update example to use the published version.
           cd example
           npm install @stacks/rendezvous@$VERSION
           cd ..
-
-          # Add the updated package.json and package-lock.json.
-          git add example/package.json
-          git add example/package-lock.json
-
-          # Commit the changes.
-          git commit -m "Update example project to use @stacks/rendezvous@$VERSION"
-
-          # Push the branch.
-          git push origin "$BRANCH_NAME"
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.BRANCH_NAME }}
+          base: master
           title: "Update example project to use @stacks/rendezvous@${{ env.VERSION }}"
+          commit-message: "Update example project to use @stacks/rendezvous@${{ env.VERSION }}"
+          add-paths: |
+            example/package.json
+            example/package-lock.json
           body: |
             This post-release PR updates the `example` Clarinet project to use the latest Rendezvous version.
 
-            **Changes:**
-            - Updates `@stacks/rendezvous` dependency to `${{ env.VERSION }}`
-
             Auto-generated after release ${{ env.VERSION }}.
-          base: master

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -19,6 +19,30 @@
         "vitest-environment-clarinet": "^2.3.0"
       }
     },
+    "..": {
+      "name": "@stacks/rendezvous",
+      "version": "0.9.0",
+      "extraneous": true,
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@hirosystems/clarinet-sdk": "^3.7.0",
+        "@stacks/transactions": "^7.2.0",
+        "ansicolor": "^2.0.3",
+        "fast-check": "^3.20.0",
+        "toml": "^3.0.0",
+        "yaml": "^2.6.1"
+      },
+      "bin": {
+        "rv": "dist/app.js"
+      },
+      "devDependencies": {
+        "@hirosystems/clarinet-sdk-wasm": "^3.7.0",
+        "@types/jest": "^29.5.12",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.2.5",
+        "typescript": "^5.5.4"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",


### PR DESCRIPTION
This PR updates the npm publish workflow to automatically update the example project with the latest published version. This keeps the example in sync without manual intervention. It also updates `example` project's `package-lock.json`.