### PR TITLE
Replace manual arg parsing with Node's args parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ npx rv <path-to-clarinet-project> <contract-name> <type>
 **Options:**
 
 - `--seed` – The seed to use for the replay functionality.
-- `--path` – The path to use for the replay functionality.
 - `--runs` – The number of test iterations to use for exercising the contracts.
   (default: `100`)
 - `--bail` – Stop after the first failure.

--- a/app.tests.ts
+++ b/app.tests.ts
@@ -72,7 +72,7 @@ describe("Command-line arguments handling", () => {
   const helpMessage = `
   rv v${version}
   
-  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>] [--dial=<path-to-dialers-file>] [--help]
+  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--runs=<runs>] [--dial=<path-to-dialers-file>] [--help]
 
   Positional arguments:
     path-to-clarinet-project - The path to the Clarinet project.
@@ -81,7 +81,6 @@ describe("Command-line arguments handling", () => {
 
   Options:
     --seed - The seed to use for the replay functionality.
-    --path - The path to use for the replay functionality.
     --runs - The runs to use for iterating over the tests. Default: 100.
     --bail - Stop after the first failure.
     --dial – The path to a JavaScript file containing custom pre- and post-execution functions (dialers).
@@ -207,23 +206,6 @@ describe("Command-line arguments handling", () => {
       ],
     ],
     [
-      ["manifest path", "contract name", "seed", "path"],
-      [
-        "node",
-        "app.js",
-        manifestDirPlaceholder,
-        "counter",
-        "--seed=123",
-        "--path=84:0",
-      ],
-      [
-        red(
-          `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`
-        ),
-        helpMessage,
-      ],
-    ],
-    [
       ["manifest path", "contract name", "runs"],
       ["node", "app.js", manifestDirPlaceholder, "counter", "--runs=10"],
       [
@@ -234,24 +216,13 @@ describe("Command-line arguments handling", () => {
       ],
     ],
     [
-      ["manifest path", "contract name", "path"],
-      ["node", "app.js", manifestDirPlaceholder, "counter", "--path=84:0"],
-      [
-        red(
-          `\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.`
-        ),
-        helpMessage,
-      ],
-    ],
-    [
-      ["manifest path", "contract name", "seed", "path", "runs"],
+      ["manifest path", "contract name", "seed", "runs"],
       [
         "node",
         "app.js",
         manifestDirPlaceholder,
         "counter",
         "--seed=123",
-        "--path=84:0",
         "--runs=10",
       ],
       [
@@ -342,7 +313,7 @@ describe("Command-line arguments handling", () => {
       ],
     ],
     [
-      ["manifest path", "contract name", "type=invariant", "seed", "path"],
+      ["manifest path", "contract name", "type=invariant", "seed"],
       [
         "node",
         "app.js",
@@ -350,13 +321,11 @@ describe("Command-line arguments handling", () => {
         "counter",
         "invariant",
         "--seed=123",
-        "--path=84:0",
       ],
       [
         `Using manifest path: ${manifestDirPlaceholder}/Clarinet.toml`,
         `Target contract: counter`,
         `Using seed: 123`,
-        `Using path: 84:0`,
         `\nStarting invariant testing type for the counter contract...\n`,
       ],
     ],
@@ -366,7 +335,6 @@ describe("Command-line arguments handling", () => {
         "contract name",
         "type=invARiaNT (case-insensitive)",
         "seed",
-        "path",
       ],
       [
         "node",
@@ -375,18 +343,16 @@ describe("Command-line arguments handling", () => {
         "counter",
         "invARiaNT",
         "--seed=123",
-        "--path=84:0",
       ],
       [
         `Using manifest path: ${manifestDirPlaceholder}/Clarinet.toml`,
         `Target contract: counter`,
         `Using seed: 123`,
-        `Using path: 84:0`,
         `\nStarting invariant testing type for the counter contract...\n`,
       ],
     ],
     [
-      ["manifest path", "contract name", "type=test", "seed", "path"],
+      ["manifest path", "contract name", "type=test", "seed"],
       [
         "node",
         "app.js",
@@ -394,18 +360,16 @@ describe("Command-line arguments handling", () => {
         "counter",
         "test",
         "--seed=123",
-        "--path=84:0",
       ],
       [
         `Using manifest path: ${manifestDirPlaceholder}/Clarinet.toml`,
         `Target contract: counter`,
         `Using seed: 123`,
-        `Using path: 84:0`,
         `\nStarting property testing type for the counter contract...\n`,
       ],
     ],
     [
-      ["manifest path", "contract name = reverse", "type=test", "seed", "path"],
+      ["manifest path", "contract name = reverse", "type=test", "seed"],
       [
         "node",
         "app.js",
@@ -413,32 +377,21 @@ describe("Command-line arguments handling", () => {
         "reverse",
         "test",
         "--seed=123",
-        "--path=84:0",
       ],
       [
         `Using manifest path: ${manifestDirPlaceholder}/Clarinet.toml`,
         `Target contract: reverse`,
         `Using seed: 123`,
-        `Using path: 84:0`,
         `\nStarting property testing type for the reverse contract...\n`,
       ],
     ],
     [
-      ["manifest path", "contract name = slice", "type=test", "seed", "path"],
-      [
-        "node",
-        "app.js",
-        manifestDirPlaceholder,
-        "slice",
-        "test",
-        "--seed=123",
-        "--path=84:0",
-      ],
+      ["manifest path", "contract name = slice", "type=test", "seed"],
+      ["node", "app.js", manifestDirPlaceholder, "slice", "test", "--seed=123"],
       [
         `Using manifest path: ${manifestDirPlaceholder}/Clarinet.toml`,
         `Target contract: slice`,
         `Using seed: 123`,
-        `Using path: 84:0`,
         `\nStarting property testing type for the slice contract...\n`,
       ],
     ],
@@ -448,7 +401,6 @@ describe("Command-line arguments handling", () => {
         "contract name",
         "type=teSt (case-insensitive)",
         "seed",
-        "path",
       ],
       [
         "node",
@@ -457,26 +409,16 @@ describe("Command-line arguments handling", () => {
         "counter",
         "teSt",
         "--seed=123",
-        "--path=84:0",
       ],
       [
         `Using manifest path: ${manifestDirPlaceholder}/Clarinet.toml`,
         `Target contract: counter`,
         `Using seed: 123`,
-        `Using path: 84:0`,
         `\nStarting property testing type for the counter contract...\n`,
       ],
     ],
     [
-      [
-        "manifest path",
-        "contract name",
-        "type=test",
-        "seed",
-        "path",
-        "runs",
-        "bail",
-      ],
+      ["manifest path", "contract name", "type=test", "seed", "runs", "bail"],
       [
         "node",
         "app.js",
@@ -484,7 +426,6 @@ describe("Command-line arguments handling", () => {
         "counter",
         "test",
         "--seed=123",
-        "--path=84:0",
         "--runs=10",
         "--bail",
       ],
@@ -492,7 +433,6 @@ describe("Command-line arguments handling", () => {
         `Using manifest path: ${manifestDirPlaceholder}/Clarinet.toml`,
         `Target contract: counter`,
         `Using seed: 123`,
-        `Using path: 84:0`,
         `Using runs: 10`,
         `Bailing on first failure.`,
         `\nStarting property testing type for the counter contract...\n`,
@@ -504,7 +444,6 @@ describe("Command-line arguments handling", () => {
         "contract name",
         "type=invariant",
         "seed",
-        "path",
         "runs",
         "bail",
       ],
@@ -515,7 +454,6 @@ describe("Command-line arguments handling", () => {
         "counter",
         "invariant",
         "--seed=123",
-        "--path=84:0",
         "--runs=10",
         "--bail",
       ],
@@ -523,7 +461,6 @@ describe("Command-line arguments handling", () => {
         `Using manifest path: ${manifestDirPlaceholder}/Clarinet.toml`,
         `Target contract: counter`,
         `Using seed: 123`,
-        `Using path: 84:0`,
         `Using runs: 10`,
         `Bailing on first failure.`,
         `\nStarting invariant testing type for the counter contract...\n`,

--- a/app.ts
+++ b/app.ts
@@ -81,7 +81,7 @@ export const tryParseRemoteDataSettings = (
 const helpMessage = `
   rv v${version}
   
-  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--path=<path>] [--runs=<runs>] [--dial=<path-to-dialers-file>] [--help]
+  Usage: rv <path-to-clarinet-project> <contract-name> <type> [--seed=<seed>] [--runs=<runs>] [--dial=<path-to-dialers-file>] [--help]
 
   Positional arguments:
     path-to-clarinet-project - The path to the Clarinet project.
@@ -90,7 +90,6 @@ const helpMessage = `
 
   Options:
     --seed - The seed to use for the replay functionality.
-    --path - The path to use for the replay functionality.
     --runs - The runs to use for iterating over the tests. Default: 100.
     --bail - Stop after the first failure.
     --dial – The path to a JavaScript file containing custom pre- and post-execution functions (dialers).
@@ -107,7 +106,6 @@ export async function main() {
     args: process.argv.slice(2),
     options: {
       seed: { type: "string" },
-      path: { type: "string" },
       runs: { type: "string" },
       dial: { type: "string" },
       bail: { type: "boolean" },
@@ -125,8 +123,6 @@ export async function main() {
     type: type?.toLowerCase(),
     /** The seed to use for the replay functionality. */
     seed: options.seed ? parseInt(options.seed, 10) : undefined,
-    /** The path to use for the replay functionality. */
-    path: options.path || undefined,
     /** The number of runs to use. */
     runs: options.runs ? parseInt(options.runs, 10) : undefined,
     /** Whether to bail on the first failure. */
@@ -188,10 +184,6 @@ export async function main() {
 
   if (runConfig.seed !== undefined) {
     radio.emit("logMessage", `Using seed: ${runConfig.seed}`);
-  }
-
-  if (runConfig.path !== undefined) {
-    radio.emit("logMessage", `Using path: ${runConfig.path}`);
   }
 
   if (runConfig.runs !== undefined) {
@@ -258,7 +250,6 @@ export async function main() {
         rendezvousList,
         rendezvousAllFunctions,
         runConfig.seed,
-        runConfig.path,
         runConfig.runs,
         runConfig.bail,
         dialerRegistry,
@@ -274,7 +265,6 @@ export async function main() {
         rendezvousList,
         rendezvousAllFunctions,
         runConfig.seed,
-        runConfig.path,
         runConfig.runs,
         runConfig.bail,
         radio

--- a/invariant.ts
+++ b/invariant.ts
@@ -30,7 +30,6 @@ import { Statistics } from "./heatstroke.types";
  * @param rendezvousAllFunctions The map of all function interfaces for each
  * target contract.
  * @param seed The seed for reproducible invariant testing.
- * @param path The path for reproducible invariant testing.
  * @param runs The number of test runs.
  * @param bail Stop execution after the first failure and prevent further
  * shrinking.
@@ -44,7 +43,6 @@ export const checkInvariants = async (
   rendezvousList: string[],
   rendezvousAllFunctions: Map<string, ContractInterfaceFunction[]>,
   seed: number | undefined,
-  path: string | undefined,
   runs: number | undefined,
   bail: boolean,
   dialerRegistry: DialerRegistry | undefined,
@@ -521,7 +519,6 @@ export const checkInvariants = async (
     {
       endOnFailure: bail,
       numRuns: runs,
-      path: path,
       reporter: radioReporter,
       seed: seed,
       verbose: true,

--- a/property.ts
+++ b/property.ts
@@ -28,7 +28,6 @@ import {
  * @param rendezvousAllFunctions A map of all target contract IDs to their
  * function interfaces.
  * @param seed The seed for reproducible property-based tests.
- * @param path The path for reproducible property-based tests.
  * @param runs The number of test runs.
  * @param bail Stop execution after the first failure and prevent further
  * shrinking.
@@ -41,7 +40,6 @@ export const checkProperties = (
   rendezvousList: string[],
   rendezvousAllFunctions: Map<string, ContractInterfaceFunction[]>,
   seed: number | undefined,
-  path: string | undefined,
   runs: number | undefined,
   bail: boolean,
   radio: EventEmitter
@@ -390,7 +388,6 @@ export const checkProperties = (
     {
       endOnFailure: bail,
       numRuns: runs,
-      path: path,
       reporter: radioReporter,
       seed: seed,
       verbose: true,


### PR DESCRIPTION
This PR replaces manual command-line argument parsing with Node's built-in `parseArgs`, consolidates all CLI arguments into a `runConfig` object for better maintainability, and removes deprecated `--path` option and tests that became irrelevant after this removal.

Resolves #165.