### PR TITLE
Document update

### DIFF
--- a/docs/chapter_6.md
+++ b/docs/chapter_6.md
@@ -229,10 +229,10 @@ async function postTransferSip010PrintEvent(context) {
   const memoGeneratedArgumentCV = clarityValueArguments[memoParameterIndex];
 
   // If the memo argument is `none`, there's nothing to validate.
-  if (memoGeneratedArgumentCV.type === 9) return;
+  if (memoGeneratedArgumentCV.type === "none") return;
 
   // Ensure the memo argument is an option (`some`).
-  if (memoGeneratedArgumentCV.type !== 10) {
+  if (memoGeneratedArgumentCV.type !== "some") {
     throw new Error("The memo argument must be an option type!");
   }
 


### PR DESCRIPTION


## Description

This is needed because it is latest stack.js type system. This pull request changes the `9 and 10` value to human-readable representation of Clarity values like in the https://github.com/stacks-network/rendezvous/blob/master/example/sip010.cjs.

```
 // If the memo argument is `none`, there's nothing to validate.
  if (memoGeneratedArgumentCV.type === "none") return;

  // Ensure the memo argument is an option (`some`).
  if (memoGeneratedArgumentCV.type !== "some") {
    throw new Error("The memo argument must be an option type!");
  }
```


## Type of Change

- Documentation update





