### PR TITLE
Fix post-release PR creation job

### DIFF
--- a/.github/workflows/npm-publish-release.yml
+++ b/.github/workflows/npm-publish-release.yml
@@ -33,6 +33,8 @@ jobs:
       BRANCH_NAME: post-release/update-example
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: "22"


### PR DESCRIPTION
This fixes the workflow that automatically creates a post-release pull request.

**The previous failed job**:
https://github.com/stacks-network/rendezvous/actions/runs/20379256036/job/58566060868

**The error message shown**:
```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/stacks-network/rendezvous/': The requested URL returned error: 400
Error: The process '/usr/bin/git' failed with exit code 128
```

After this change, **the job runs successfully**:
https://github.com/BowTiedRadone/rendezvous/actions/runs/20463688905/job/58802114944

**Automatically opened PR** while testing the fix:
https://github.com/BowTiedRadone/rendezvous/pull/9