### PR TITLE
docs: fix README typo and update repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/stacks-network/rendezvous.git"
+    "url": "https://github.com/AdekunleBamz/rendezvous.git"
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",


### PR DESCRIPTION
## What
- Fix typo in README.md: "Uncover ulnerabilities" → "Uncover vulnerabilities".
- Update package.json repository URL to point to AdekunleBamz/rendezvous.

## Why
- Improves documentation readability.
- Ensures npm metadata links to the correct repo.

## How to verify
- README.md line 7 now reads correctly.
- package.json repository field updated.