### PR TITLE
Add support for config file and refactor run config parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
           rv . self-listing-helper-v3a test
           rv . self-listing-helper-v3a invariant
           rv . rendezvous-token invariant --dial=./sip010.cjs
+          rv . counter test --config=rv.config.json
 
   generate-docs:
     needs: [tests, examples]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ npx rv <path-to-clarinet-project> <contract-name> <type>
 
 **Options:**
 
+- `--config` – Path to a JSON config file. When provided, all run options come
+  from the config file exclusively (CLI flags are ignored).
 - `--seed` – The seed to use for the replay functionality.
 - `--runs` – The number of test iterations to use for exercising the contracts.
   (default: `100`)

--- a/app.tests.ts
+++ b/app.tests.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 import { red } from "ansicolor";
 
 import { getManifestFileName, main } from "./app";
-import { version } from "./package.json";
+import { helpMessage } from "./cli";
 import { getFailureFilePath } from "./persistence";
 import { LOG_DIVIDER } from "./shared";
 import { createIsolatedTestEnvironment } from "./test.utils";
@@ -14,27 +14,6 @@ const isolatedTestEnvPrefix = "rendezvous-test-app-";
 describe("Command-line arguments handling", () => {
   const initialArgv = process.argv;
 
-  const helpMessage = `
-  rv v${version}
-  
-  Usage: rv <path> <contract> <type> [OPTIONS]
-
-  Arguments:
-    <path>        Path to the Clarinet project
-    <contract>    Contract name to fuzz
-    <type>        Test type: test | invariant
-
-  Options:
-    --seed=<n>    Seed for replay functionality
-    --runs=<n>    Number of test iterations [default: 100]
-    --dial=<f>    Path to custom dialers file
-    --regr        Run regression tests only
-    --bail        Stop on first failure
-    -h, --help    Show this message
-
-  Learn more: https://stacks-network.github.io/rendezvous/
-  `;
-
   const noManifestMessage = red(
     `\nNo path to Clarinet project provided. Supply it immediately or face the relentless scrutiny of your contract's vulnerabilities.`,
   );
@@ -43,23 +22,9 @@ describe("Command-line arguments handling", () => {
   );
   const manifestDirPlaceholder = "isolated-example";
 
-  it.each([
-    ["manifest path", ["node", "app.js"]],
-    ["target contract name", ["node", "app.js", "./path/to/clarinet/project"]],
-    ["--help flag", ["node", "app.js", "--help"]],
-  ])(
-    "returns undefined when %s is not provided",
-    async (_testCase: string, argv: string[]) => {
-      process.argv = argv;
-      expect(await main()).toBeUndefined();
-      process.argv = initialArgv;
-    },
-  );
-
-  it("logs the help message at the end when --help is specified", async () => {
+  it("returns cleanly when --help is specified", async () => {
     // Arrange
     process.argv = ["node", "app.js", "--help"];
-
     const consoleLogs: string[] = [];
     jest.spyOn(console, "log").mockImplementation((message: string) => {
       consoleLogs.push(message);
@@ -68,15 +33,37 @@ describe("Command-line arguments handling", () => {
     // Act
     await main();
 
-    const actual = consoleLogs[consoleLogs.length - 1];
-
     // Assert
-    const expected = helpMessage;
-    expect(actual).toBe(expected);
+    expect(consoleLogs).toContain(helpMessage);
 
+    // Teardown
     process.argv = initialArgv;
     jest.restoreAllMocks();
   });
+
+  it.each([
+    ["manifest path", ["node", "app.js"]],
+    ["target contract name", ["node", "app.js", "./path/to/clarinet/project"]],
+  ])(
+    "exits with code 1 when %s is not provided",
+    async (_testCase: string, argv: string[]) => {
+      // Arrange
+      process.argv = argv;
+      const mockExit = jest.spyOn(process, "exit").mockImplementation(((
+        _code?: number,
+      ) => {
+        throw new Error("process.exit");
+      }) as () => never);
+
+      // Act & Assert
+      await expect(main()).rejects.toThrow("process.exit");
+      expect(mockExit).toHaveBeenCalledWith(1);
+
+      // Teardown
+      process.argv = initialArgv;
+      jest.restoreAllMocks();
+    },
+  );
 
   it.each([
     ["manifest path", ["node", "app.js"], noManifestMessage],
@@ -86,27 +73,30 @@ describe("Command-line arguments handling", () => {
       noContractNameMessage,
     ],
   ])(
-    "logs the info and the help message when the %s is not provided",
-    async (_testCase: string, argv: string[], expected: string) => {
+    "logs the error and help message when the %s is not provided",
+    async (_testCase: string, argv: string[], expectedError: string) => {
       // Arrange
       process.argv = argv;
       const consoleLogs: string[] = [];
+      const consoleErrors: string[] = [];
       jest.spyOn(console, "log").mockImplementation((message: string) => {
         consoleLogs.push(message);
       });
+      jest.spyOn(console, "error").mockImplementation((message: string) => {
+        consoleErrors.push(message);
+      });
+      jest.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+        throw new Error("process.exit");
+      }) as () => never);
 
       // Act
-      await main();
-
-      const actualLastLog = consoleLogs[consoleLogs.length - 1];
-      const actualSecondToLastLog = consoleLogs[consoleLogs.length - 2];
+      await expect(main()).rejects.toThrow("process.exit");
 
       // Assert
-      const expectedLastLog = helpMessage;
+      expect(consoleErrors).toContain(expectedError);
+      expect(consoleLogs).toContain(helpMessage);
 
-      expect(actualLastLog).toBe(expectedLastLog);
-      expect(actualSecondToLastLog).toBe(expected);
-
+      // Teardown
       process.argv = initialArgv;
       jest.restoreAllMocks();
     },
@@ -476,11 +466,16 @@ describe("Command-line arguments handling", () => {
       );
       process.argv = updatedArgv;
 
-      const consoleLogs: string[] = [];
+      const allLogs: string[] = [];
       jest.spyOn(console, "log").mockImplementation((message: string) => {
-        consoleLogs.push(message);
+        allLogs.push(message);
       });
-      jest.spyOn(console, "error").mockImplementation(() => {});
+      jest.spyOn(console, "error").mockImplementation((message: string) => {
+        allLogs.push(message);
+      });
+      jest.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+        throw new Error("process.exit");
+      }) as () => never);
 
       // Exercise
       try {
@@ -498,7 +493,7 @@ describe("Command-line arguments handling", () => {
           ? expectedLog.replace(manifestDirPlaceholder, tempDir)
           : expectedLog;
 
-        expect(consoleLogs).toContain(updatedExpectedLog);
+        expect(allLogs).toContain(updatedExpectedLog);
       });
 
       // Teardown

--- a/app.ts
+++ b/app.ts
@@ -6,7 +6,7 @@ import { join, resolve } from "node:path";
 import { initSimnet } from "@stacks/clarinet-sdk";
 import { red } from "ansicolor";
 
-import { helpMessage, logRunConfig, parseCli, RunConfig } from "./cli";
+import { helpMessage, logRunConfig, parseCli, type RunConfig } from "./cli";
 import { resolveAccounts } from "./config";
 import { checkInvariants } from "./invariant";
 import { checkProperties } from "./property";

--- a/app.ts
+++ b/app.ts
@@ -2,19 +2,18 @@
 import { EventEmitter } from "node:events";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { parseArgs } from "node:util";
 
 import { initSimnet } from "@stacks/clarinet-sdk";
 import { red } from "ansicolor";
 
+import { helpMessage, logRunConfig, parseCli } from "./cli";
+import { resolveAccounts } from "./config";
 import { checkInvariants } from "./invariant";
-import { version } from "./package.json";
 import { checkProperties } from "./property";
 import {
   getContractNameFromContractId,
   getFunctionsFromContractInterfaces,
   getSimnetDeployerContractsInterfaces,
-  LOG_DIVIDER,
 } from "./shared";
 
 const logger = (log: string, logLevel: "log" | "error" | "info" = "log") => {
@@ -44,142 +43,45 @@ export const getManifestFileName = (
   return "Clarinet.toml";
 };
 
-const helpMessage = `
-  rv v${version}
-  
-  Usage: rv <path> <contract> <type> [OPTIONS]
-
-  Arguments:
-    <path>        Path to the Clarinet project
-    <contract>    Contract name to fuzz
-    <type>        Test type: test | invariant
-
-  Options:
-    --seed=<n>    Seed for replay functionality
-    --runs=<n>    Number of test iterations [default: 100]
-    --dial=<f>    Path to custom dialers file
-    --regr        Run regression tests only
-    --bail        Stop on first failure
-    -h, --help    Show this message
-
-  Learn more: https://stacks-network.github.io/rendezvous/
-  `;
+const parseCliOrExit = (argv: string[], radio: EventEmitter) => {
+  try {
+    return parseCli(argv);
+  } catch (err: unknown) {
+    radio.emit(
+      "logFailure",
+      `\n${err instanceof Error ? err.message : String(err)}`,
+    );
+    radio.emit("logMessage", helpMessage);
+    process.exit(1);
+  }
+};
 
 export const main = async () => {
   const radio = new EventEmitter();
   radio.on("logMessage", (log) => logger(log));
   radio.on("logFailure", (log) => logger(red(log), "error"));
 
-  const { positionals: positionalArgs, values: options } = parseArgs({
-    allowPositionals: true,
-    args: process.argv.slice(2),
-    options: {
-      seed: { type: "string" },
-      runs: { type: "string" },
-      dial: { type: "string" },
-      bail: { type: "boolean" },
-      regr: { type: "boolean" },
-      help: { type: "boolean", short: "h" },
-    },
-  });
+  const runConfig = parseCliOrExit(process.argv.slice(2), radio);
 
-  const [manifestDir, sutContractName, type] = positionalArgs;
-  const runConfig = {
-    /** The relative path to the Clarinet project. */
-    manifestDir: manifestDir,
-    /** The target contract name. */
-    sutContractName: sutContractName,
-    /** The type of testing to be executed. Valid values: test, invariant. */
-    type: type?.toLowerCase(),
-    /** The seed to use for the replay functionality. */
-    seed: options.seed ? parseInt(options.seed, 10) : undefined,
-    /** The number of runs to use. */
-    runs: options.runs ? parseInt(options.runs, 10) : undefined,
-    /** Whether to bail on the first failure. */
-    bail: options.bail || false,
-    /** Whether to run regression tests only. */
-    regr: options.regr || false,
-    /** The path to the dialer file. */
-    dial: options.dial || undefined,
-    /** Whether to show the help message. */
-    help: options.help || false,
-  };
-
-  if (runConfig.help) {
+  if (!runConfig) {
     radio.emit("logMessage", helpMessage);
     return;
   }
 
-  if (!runConfig.manifestDir) {
-    radio.emit(
-      "logMessage",
-      red(
-        "\nNo path to Clarinet project provided. Supply it immediately or face the relentless scrutiny of your contract's vulnerabilities.",
-      ),
-    );
-    radio.emit("logMessage", helpMessage);
-    return;
-  }
-
-  if (!runConfig.sutContractName) {
-    radio.emit(
-      "logMessage",
-      red(
-        "\nNo target contract name provided. Please provide the contract name to be fuzzed.",
-      ),
-    );
-    radio.emit("logMessage", helpMessage);
-    return;
-  }
-
-  if (!runConfig.type || !["test", "invariant"].includes(runConfig.type)) {
-    radio.emit(
-      "logMessage",
-      red(
-        "\nInvalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.",
-      ),
-    );
-    radio.emit("logMessage", helpMessage);
-    return;
-  }
-
-  // Divider before the run configuration.
-  radio.emit("logMessage", LOG_DIVIDER);
-  /**
-   * The relative path to the manifest file, either `Clarinet.toml` or
-   * `Clarinet-<contract-name>.toml`. If the latter exists, it is used.
-   */
   const manifestPath = join(
     runConfig.manifestDir,
     getManifestFileName(runConfig.manifestDir, runConfig.sutContractName),
   );
-  radio.emit("logMessage", `Using manifest path: ${manifestPath}`);
-  radio.emit("logMessage", `Target contract: ${runConfig.sutContractName}`);
 
-  if (runConfig.seed !== undefined) {
-    radio.emit("logMessage", `Using seed: ${runConfig.seed}`);
-  }
-
-  if (runConfig.runs !== undefined) {
-    radio.emit("logMessage", `Using runs: ${runConfig.runs}`);
-  }
-
-  if (runConfig.bail) {
-    radio.emit("logMessage", `Bailing on first failure.`);
-  }
-
-  if (runConfig.regr) {
-    radio.emit("logMessage", `Running regression tests.`);
-  }
-
-  if (runConfig.dial !== undefined) {
-    radio.emit("logMessage", `Using dial path: ${runConfig.dial}`);
-  }
-
-  // Divider between the run configuration and the execution.
-  radio.emit("logMessage", LOG_DIVIDER + "\n");
+  logRunConfig(radio, runConfig, manifestPath);
 
   const simnet = await initSimnet(manifestPath);
+
+  const { eligibleAccounts, allAddresses } = resolveAccounts(
+    simnet.getAccounts(),
+    runConfig.accounts,
+    runConfig.accountsMode,
+  );
 
   const resetSession = async () => {
     await initSimnet(manifestPath);
@@ -214,8 +116,6 @@ export const main = async () => {
   );
 
   // Select the testing routine based on `type`.
-  // If "invariant", call `checkInvariants` to verify contract invariants.
-  // If "test", call `checkProperties` for property-based testing.
   switch (runConfig.type) {
     case "invariant": {
       await checkInvariants(
@@ -229,6 +129,8 @@ export const main = async () => {
         runConfig.bail,
         runConfig.regr,
         radio,
+        eligibleAccounts,
+        allAddresses,
       );
       break;
     }
@@ -244,6 +146,8 @@ export const main = async () => {
         runConfig.bail,
         runConfig.regr,
         radio,
+        eligibleAccounts,
+        allAddresses,
       );
       break;
     }

--- a/app.ts
+++ b/app.ts
@@ -4,9 +4,15 @@ import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import { initSimnet } from "@stacks/clarinet-sdk";
-import { red } from "ansicolor";
+import { red, yellow } from "ansicolor";
 
-import { helpMessage, logRunConfig, parseCli, type RunConfig } from "./cli";
+import {
+  helpMessage,
+  logRunConfig,
+  logWarnings,
+  parseCli,
+  type RunConfig,
+} from "./cli";
 import { resolveAccounts } from "./config";
 import { checkInvariants } from "./invariant";
 import { checkProperties } from "./property";
@@ -62,6 +68,7 @@ const parseCliOrExit = (
 export const main = async () => {
   const radio = new EventEmitter();
   radio.on("logMessage", (log) => logger(log));
+  radio.on("logInfo", (log) => logger(yellow(log), "info"));
   radio.on("logFailure", (log) => logger(red(log), "error"));
 
   const runConfig = parseCliOrExit(process.argv.slice(2), radio);
@@ -70,6 +77,8 @@ export const main = async () => {
     radio.emit("logMessage", helpMessage);
     return;
   }
+
+  logWarnings(radio, runConfig.warnings);
 
   const manifestPath = join(
     runConfig.manifestDir,

--- a/app.ts
+++ b/app.ts
@@ -6,7 +6,7 @@ import { join, resolve } from "node:path";
 import { initSimnet } from "@stacks/clarinet-sdk";
 import { red } from "ansicolor";
 
-import { helpMessage, logRunConfig, parseCli } from "./cli";
+import { helpMessage, logRunConfig, parseCli, RunConfig } from "./cli";
 import { resolveAccounts } from "./config";
 import { checkInvariants } from "./invariant";
 import { checkProperties } from "./property";
@@ -43,7 +43,10 @@ export const getManifestFileName = (
   return "Clarinet.toml";
 };
 
-const parseCliOrExit = (argv: string[], radio: EventEmitter) => {
+const parseCliOrExit = (
+  argv: string[],
+  radio: EventEmitter,
+): RunConfig | undefined => {
   try {
     return parseCli(argv);
   } catch (err: unknown) {

--- a/cli.tests.ts
+++ b/cli.tests.ts
@@ -149,6 +149,24 @@ describe("CLI parsing with parseCli", () => {
     ).toThrow("Config file not found:");
   });
 
+  it("throws when --seed is not an integer", () => {
+    expect(() => parseCli(["./example", "counter", "test", "--seed=abc"])).toThrow(
+      `"seed" must be an integer.`,
+    );
+  });
+
+  it("throws when --runs is not a positive integer", () => {
+    expect(() => parseCli(["./example", "counter", "test", "--runs=0"])).toThrow(
+      `"runs" must be a positive integer.`,
+    );
+  });
+
+  it("throws when --runs is not a number", () => {
+    expect(() => parseCli(["./example", "counter", "test", "--runs=abc"])).toThrow(
+      `"runs" must be a positive integer.`,
+    );
+  });
+
   it("defaults accountsMode to overwrite when not specified", () => {
     const config = parseCli(["./example", "counter", "test"])!;
     expect(config.accountsMode).toBe("overwrite");

--- a/cli.tests.ts
+++ b/cli.tests.ts
@@ -1,0 +1,156 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { parseCli } from "./cli";
+
+describe("CLI parsing with parseCli", () => {
+  it("returns undefined when --help is passed", () => {
+    expect(parseCli(["--help"])).toBeUndefined();
+  });
+
+  it("throws when no arguments are provided", () => {
+    expect(() => parseCli([])).toThrow("No path to Clarinet project provided.");
+  });
+
+  it("throws when only manifest path is provided", () => {
+    expect(() => parseCli(["./example"])).toThrow(
+      "No target contract name provided.",
+    );
+  });
+
+  it("throws when type is invalid", () => {
+    expect(() => parseCli(["./example", "counter", "invalid"])).toThrow(
+      "Invalid type provided.",
+    );
+  });
+
+  it("returns a valid RunConfig with all CLI options", () => {
+    const config = parseCli([
+      "./example",
+      "counter",
+      "invariant",
+      "--seed=42",
+      "--runs=200",
+      "--bail",
+      "--regr",
+      "--dial=./dialers.cjs",
+    ])!;
+
+    expect(config.manifestDir).toBe("./example");
+    expect(config.sutContractName).toBe("counter");
+    expect(config.type).toBe("invariant");
+    expect(config.seed).toBe(42);
+    expect(config.runs).toBe(200);
+    expect(config.bail).toBe(true);
+    expect(config.regr).toBe(true);
+    expect(config.dial).toBe("./dialers.cjs");
+  });
+
+  it("normalizes type to lowercase", () => {
+    const config = parseCli(["./example", "counter", "InVaRiAnT"])!;
+    expect(config.type).toBe("invariant");
+  });
+
+  it("uses config file values exclusively when --config is provided, ignoring CLI flags", () => {
+    // Arrange
+    const tempDir = join(tmpdir(), "rendezvous-test-parsecli");
+    mkdirSync(tempDir, { recursive: true });
+    const configPath = join(tempDir, "rv.config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ seed: 100, runs: 500, bail: true }),
+      "utf-8",
+    );
+
+    // Act — CLI also passes --seed=999 and --runs=10, but config wins.
+    const config = parseCli([
+      "./example",
+      "counter",
+      "test",
+      `--config=${configPath}`,
+      "--seed=999",
+      "--runs=10",
+    ])!;
+
+    // Assert — only config values are used.
+    expect(config.seed).toBe(100);
+    expect(config.runs).toBe(500);
+    expect(config.bail).toBe(true);
+
+    // Teardown
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("uses CLI flags exclusively when --config is not provided", () => {
+    const config = parseCli([
+      "./example",
+      "counter",
+      "test",
+      "--seed=42",
+      "--runs=200",
+      "--bail",
+    ])!;
+
+    expect(config.seed).toBe(42);
+    expect(config.runs).toBe(200);
+    expect(config.bail).toBe(true);
+    expect(config.accounts).toBeUndefined();
+  });
+
+  it("loads accounts from config file", () => {
+    // Arrange
+    const tempDir = join(tmpdir(), "rendezvous-test-parsecli-accounts");
+    mkdirSync(tempDir, { recursive: true });
+    const configPath = join(tempDir, "rv.config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        accounts: [
+          {
+            name: "whale_1",
+            address: "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
+          },
+        ],
+        accounts_mode: "overwrite",
+      }),
+      "utf-8",
+    );
+
+    // Act
+    const config = parseCli([
+      "./example",
+      "counter",
+      "test",
+      `--config=${configPath}`,
+    ])!;
+
+    // Assert
+    expect(config.accounts).toEqual([
+      {
+        name: "whale_1",
+        address: "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
+      },
+    ]);
+    expect(config.accountsMode).toBe("overwrite");
+
+    // Teardown
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("throws when config file does not exist", () => {
+    expect(() =>
+      parseCli([
+        "./example",
+        "counter",
+        "test",
+        "--config=/tmp/nonexistent-rv-test.json",
+      ]),
+    ).toThrow("Config file not found:");
+  });
+
+  it("defaults accountsMode to overwrite when not specified", () => {
+    const config = parseCli(["./example", "counter", "test"])!;
+    expect(config.accountsMode).toBe("overwrite");
+  });
+});

--- a/cli.tests.ts
+++ b/cli.tests.ts
@@ -150,21 +150,21 @@ describe("CLI parsing with parseCli", () => {
   });
 
   it("throws when --seed is not an integer", () => {
-    expect(() => parseCli(["./example", "counter", "test", "--seed=abc"])).toThrow(
-      `"seed" must be an integer.`,
-    );
+    expect(() =>
+      parseCli(["./example", "counter", "test", "--seed=abc"]),
+    ).toThrow(`"seed" must be an integer.`);
   });
 
   it("throws when --runs is not a positive integer", () => {
-    expect(() => parseCli(["./example", "counter", "test", "--runs=0"])).toThrow(
-      `"runs" must be a positive integer.`,
-    );
+    expect(() =>
+      parseCli(["./example", "counter", "test", "--runs=0"]),
+    ).toThrow(`"runs" must be a positive integer.`);
   });
 
   it("throws when --runs is not a number", () => {
-    expect(() => parseCli(["./example", "counter", "test", "--runs=abc"])).toThrow(
-      `"runs" must be a positive integer.`,
-    );
+    expect(() =>
+      parseCli(["./example", "counter", "test", "--runs=abc"]),
+    ).toThrow(`"runs" must be a positive integer.`);
   });
 
   it("defaults accountsMode to overwrite when not specified", () => {

--- a/cli.tests.ts
+++ b/cli.tests.ts
@@ -171,4 +171,66 @@ describe("CLI parsing with parseCli", () => {
     const config = parseCli(["./example", "counter", "test"])!;
     expect(config.accountsMode).toBe("overwrite");
   });
+
+  it("warns when CLI flags are used alongside --config", () => {
+    // Arrange
+    const tempDir = join(tmpdir(), "rendezvous-test-parsecli-warn-flags");
+    mkdirSync(tempDir, { recursive: true });
+    const configPath = join(tempDir, "rv.config.json");
+    writeFileSync(configPath, JSON.stringify({ seed: 1 }), "utf-8");
+
+    // Act
+    const config = parseCli([
+      "./example",
+      "counter",
+      "test",
+      `--config=${configPath}`,
+      "--seed=999",
+      "--bail",
+    ])!;
+
+    // Assert
+    expect(config.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("--seed"),
+        expect.stringContaining("--bail"),
+      ]),
+    );
+
+    // Teardown
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("warns when config file contains unrecognized keys", () => {
+    // Arrange
+    const tempDir = join(tmpdir(), "rendezvous-test-parsecli-warn-keys");
+    mkdirSync(tempDir, { recursive: true });
+    const configPath = join(tempDir, "rv.config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ sedd: 42, bail: true }),
+      "utf-8",
+    );
+
+    // Act
+    const config = parseCli([
+      "./example",
+      "counter",
+      "test",
+      `--config=${configPath}`,
+    ])!;
+
+    // Assert
+    expect(config.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining("sedd")]),
+    );
+
+    // Teardown
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns no warnings for valid CLI-only usage", () => {
+    const config = parseCli(["./example", "counter", "test", "--seed=42"])!;
+    expect(config.warnings).toEqual([]);
+  });
 });

--- a/cli.ts
+++ b/cli.ts
@@ -1,0 +1,179 @@
+import type { EventEmitter } from "node:events";
+import { parseArgs } from "node:util";
+
+import {
+  loadConfig,
+  type AccountsMode,
+  type ConfigAccount,
+  type RendezvousConfig,
+} from "./config";
+import { version } from "./package.json";
+import { LOG_DIVIDER } from "./shared";
+
+export const helpMessage = `
+  rv v${version}
+
+  Usage: rv <path> <contract> <type> [OPTIONS]
+
+  Arguments:
+    <path>        Path to the Clarinet project
+    <contract>    Contract name to fuzz
+    <type>        Test type: test | invariant
+
+  Options:
+    --config=<f>  Path to config file (JSON)
+    --seed=<n>    Seed for replay functionality
+    --runs=<n>    Number of test iterations [default: 100]
+    --dial=<f>    Path to custom dialers file
+    --regr        Run regression tests only
+    --bail        Stop on first failure
+    -h, --help    Show this message
+
+  Learn more: https://stacks-network.github.io/rendezvous/
+  `;
+
+/**
+ * The resolved run configuration, ready to use.
+ */
+export interface RunConfig {
+  manifestDir: string;
+  sutContractName: string;
+  type: "test" | "invariant";
+  seed: number | undefined;
+  runs: number | undefined;
+  bail: boolean;
+  regr: boolean;
+  dial: string | undefined;
+  accounts: ConfigAccount[] | undefined;
+  accountsMode: AccountsMode;
+  configPath: string | undefined;
+}
+
+/**
+ * Parses CLI arguments into a `RunConfig`.
+ *
+ * If `--config` is provided, all run options come from the config file
+ * exclusively. Otherwise, all run options come from CLI flags exclusively.
+ * The two sources are never merged.
+ *
+ * Returns `undefined` for `--help` (clean exit).
+ * Throws on invalid arguments or config errors.
+ */
+export const parseCli = (argv: string[]): RunConfig | undefined => {
+  const { positionals: positionalArgs, values: options } = parseArgs({
+    allowPositionals: true,
+    args: argv,
+    options: {
+      config: { type: "string" },
+      seed: { type: "string" },
+      runs: { type: "string" },
+      dial: { type: "string" },
+      bail: { type: "boolean" },
+      regr: { type: "boolean" },
+      help: { type: "boolean", short: "h" },
+    },
+  });
+
+  if (options.help) {
+    return undefined;
+  }
+
+  // Load config file if provided.
+  let fileConfig: RendezvousConfig = {};
+  if (options.config) {
+    fileConfig = loadConfig(options.config);
+  }
+
+  const [manifestDir, sutContractName, type] = positionalArgs;
+
+  if (!manifestDir) {
+    throw new Error(
+      "No path to Clarinet project provided. Supply it immediately or face the relentless scrutiny of your contract's vulnerabilities.",
+    );
+  }
+
+  if (!sutContractName) {
+    throw new Error(
+      "No target contract name provided. Please provide the contract name to be fuzzed.",
+    );
+  }
+
+  const normalizedType = type?.toLowerCase();
+  if (!normalizedType || !["test", "invariant"].includes(normalizedType)) {
+    throw new Error(
+      "Invalid type provided. Please provide the type of test to be executed. Possible values: test, invariant.",
+    );
+  }
+
+  // If a config file is provided, use its values exclusively.
+  // Otherwise, use CLI options.
+  if (options.config) {
+    return {
+      manifestDir,
+      sutContractName,
+      type: normalizedType as "test" | "invariant",
+      seed: fileConfig.seed,
+      runs: fileConfig.runs,
+      bail: fileConfig.bail ?? false,
+      regr: fileConfig.regr ?? false,
+      dial: fileConfig.dial,
+      accounts: fileConfig.accounts,
+      accountsMode: fileConfig.accounts_mode ?? "overwrite",
+      configPath: options.config,
+    };
+  }
+
+  return {
+    manifestDir,
+    sutContractName,
+    type: normalizedType as "test" | "invariant",
+    seed: options.seed ? parseInt(options.seed, 10) : undefined,
+    runs: options.runs ? parseInt(options.runs, 10) : undefined,
+    bail: options.bail ?? false,
+    regr: options.regr ?? false,
+    dial: options.dial,
+    accounts: undefined,
+    accountsMode: "overwrite",
+    configPath: undefined,
+  };
+};
+
+/**
+ * Emits the run configuration summary to the radio.
+ */
+export const logRunConfig = (
+  radio: EventEmitter,
+  config: RunConfig,
+  manifestPath: string,
+) => {
+  radio.emit("logMessage", LOG_DIVIDER);
+  radio.emit("logMessage", `Using manifest path: ${manifestPath}`);
+  radio.emit("logMessage", `Target contract: ${config.sutContractName}`);
+
+  if (config.seed !== undefined) {
+    radio.emit("logMessage", `Using seed: ${config.seed}`);
+  }
+  if (config.runs !== undefined) {
+    radio.emit("logMessage", `Using runs: ${config.runs}`);
+  }
+  if (config.bail) {
+    radio.emit("logMessage", `Bailing on first failure.`);
+  }
+  if (config.regr) {
+    radio.emit("logMessage", `Running regression tests.`);
+  }
+  if (config.dial !== undefined) {
+    radio.emit("logMessage", `Using dial path: ${config.dial}`);
+  }
+  if (config.configPath) {
+    radio.emit("logMessage", `Using config file: ${config.configPath}`);
+  }
+  if (config.accounts !== undefined && config.accounts.length > 0) {
+    radio.emit(
+      "logMessage",
+      `Custom accounts: ${config.accounts.length} (mode: ${config.accountsMode})`,
+    );
+  }
+
+  radio.emit("logMessage", LOG_DIVIDER + "\n");
+};

--- a/cli.ts
+++ b/cli.ts
@@ -47,6 +47,7 @@ export interface RunConfig {
   accounts: ConfigAccount[] | undefined;
   accountsMode: AccountsMode;
   configPath: string | undefined;
+  warnings: string[];
 }
 
 /**
@@ -80,8 +81,16 @@ export const parseCli = (argv: string[]): RunConfig | undefined => {
 
   // Load config file if provided.
   let fileConfig: RendezvousConfig = {};
+  const configWarnings: string[] = [];
   if (options.config) {
-    fileConfig = loadConfig(options.config);
+    const result = loadConfig(options.config);
+    fileConfig = result.config;
+
+    if (result.unknownKeys.length > 0) {
+      configWarnings.push(
+        `Warning: unrecognized config keys: ${result.unknownKeys.join(", ")}.`,
+      );
+    }
   }
 
   const [manifestDir, sutContractName, type] = positionalArgs;
@@ -108,6 +117,20 @@ export const parseCli = (argv: string[]): RunConfig | undefined => {
   // If a config file is provided, use its values exclusively.
   // Otherwise, use CLI options.
   if (options.config) {
+    const ignoredFlags = [
+      options.seed && "--seed",
+      options.runs && "--runs",
+      options.bail && "--bail",
+      options.regr && "--regr",
+      options.dial && "--dial",
+    ].filter(Boolean) as string[];
+
+    if (ignoredFlags.length > 0) {
+      configWarnings.push(
+        `Warning: ${ignoredFlags.join(", ")} ignored when --config is used.`,
+      );
+    }
+
     return {
       manifestDir,
       sutContractName,
@@ -120,6 +143,7 @@ export const parseCli = (argv: string[]): RunConfig | undefined => {
       accounts: fileConfig.accounts,
       accountsMode: fileConfig.accounts_mode ?? "overwrite",
       configPath: options.config,
+      warnings: configWarnings,
     };
   }
 
@@ -147,6 +171,7 @@ export const parseCli = (argv: string[]): RunConfig | undefined => {
     accounts: undefined,
     accountsMode: "overwrite",
     configPath: undefined,
+    warnings: [],
   };
 };
 
@@ -188,4 +213,10 @@ export const logRunConfig = (
   }
 
   radio.emit("logMessage", LOG_DIVIDER + "\n");
+};
+
+export const logWarnings = (radio: EventEmitter, warnings: string[]) => {
+  for (const warning of warnings) {
+    radio.emit("logInfo", warning);
+  }
 };

--- a/cli.ts
+++ b/cli.ts
@@ -130,7 +130,9 @@ export const parseCli = (argv: string[]): RunConfig | undefined => {
 
   const runs = options.runs ? parseInt(options.runs, 10) : undefined;
   if (runs !== undefined && (!Number.isInteger(runs) || runs < 1)) {
-    throw new Error(`"runs" must be a positive integer. Got: "${options.runs}".`);
+    throw new Error(
+      `"runs" must be a positive integer. Got: "${options.runs}".`,
+    );
   }
 
   return {

--- a/cli.ts
+++ b/cli.ts
@@ -123,12 +123,22 @@ export const parseCli = (argv: string[]): RunConfig | undefined => {
     };
   }
 
+  const seed = options.seed ? parseInt(options.seed, 10) : undefined;
+  if (seed !== undefined && (!Number.isInteger(seed) || isNaN(seed))) {
+    throw new Error(`"seed" must be an integer. Got: "${options.seed}".`);
+  }
+
+  const runs = options.runs ? parseInt(options.runs, 10) : undefined;
+  if (runs !== undefined && (!Number.isInteger(runs) || runs < 1)) {
+    throw new Error(`"runs" must be a positive integer. Got: "${options.runs}".`);
+  }
+
   return {
     manifestDir,
     sutContractName,
     type: normalizedType as "test" | "invariant",
-    seed: options.seed ? parseInt(options.seed, 10) : undefined,
-    runs: options.runs ? parseInt(options.runs, 10) : undefined,
+    seed,
+    runs,
     bail: options.bail ?? false,
     regr: options.regr ?? false,
     dial: options.dial,

--- a/config.tests.ts
+++ b/config.tests.ts
@@ -1,0 +1,274 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { loadConfig, resolveAccounts, type ConfigAccount } from "./config";
+
+const temporaryTestBaseDir = resolve(tmpdir(), "rendezvous-test-config");
+
+const createTempConfigFile = (dirName: string, content: string): string => {
+  const dir = join(temporaryTestBaseDir, dirName);
+  mkdirSync(dir, { recursive: true });
+  const filePath = join(dir, "rv.config.json");
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+};
+
+afterAll(() => {
+  rmSync(temporaryTestBaseDir, { recursive: true, force: true });
+});
+
+describe("Config loading and validation", () => {
+  it("throws when the config file does not exist", () => {
+    // Arrange
+    const nonExistentPath = "/tmp/nonexistent-rv-config.json";
+
+    // Act & Assert
+    expect(() => loadConfig(nonExistentPath)).toThrow("Config file not found:");
+  });
+
+  it("throws when the config file contains invalid JSON", () => {
+    // Arrange
+    const filePath = createTempConfigFile("invalid-json", "not json {{{");
+
+    // Act & Assert
+    expect(() => loadConfig(filePath)).toThrow(
+      "Failed to parse config file as JSON:",
+    );
+  });
+
+  it("throws when the config file is not a JSON object", () => {
+    // Arrange
+    const filePath = createTempConfigFile("array-root", "[1, 2, 3]");
+
+    // Act & Assert
+    expect(() => loadConfig(filePath)).toThrow(
+      "Config file must contain a JSON object.",
+    );
+  });
+
+  it("returns an empty config for an empty JSON object", () => {
+    // Arrange
+    const filePath = createTempConfigFile("empty-object", "{}");
+
+    // Act
+    const config = loadConfig(filePath);
+
+    // Assert
+    expect(config).toEqual({});
+  });
+
+  it("parses a valid config with all fields", () => {
+    // Arrange
+    const content = JSON.stringify({
+      accounts: [
+        {
+          name: "whale_1",
+          address: "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
+        },
+      ],
+      accounts_mode: "overwrite",
+      seed: 42,
+      runs: 500,
+      bail: true,
+      regr: false,
+      dial: "./dialers.cjs",
+    });
+    const filePath = createTempConfigFile("all-fields", content);
+
+    // Act
+    const config = loadConfig(filePath);
+
+    // Assert
+    expect(config.accounts).toEqual([
+      { name: "whale_1", address: "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE" },
+    ]);
+    expect(config.accounts_mode).toBe("overwrite");
+    expect(config.seed).toBe(42);
+    expect(config.runs).toBe(500);
+    expect(config.bail).toBe(true);
+    expect(config.regr).toBe(false);
+    expect(config.dial).toBe("./dialers.cjs");
+  });
+
+  it("throws when accounts is not an array", () => {
+    // Arrange
+    const filePath = createTempConfigFile(
+      "accounts-not-array",
+      JSON.stringify({ accounts: "not-an-array" }),
+    );
+
+    // Act & Assert
+    expect(() => loadConfig(filePath)).toThrow(`"accounts" must be an array.`);
+  });
+
+  it("throws when an account entry is missing the name field", () => {
+    // Arrange
+    const filePath = createTempConfigFile(
+      "account-no-name",
+      JSON.stringify({
+        accounts: [{ address: "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE" }],
+      }),
+    );
+
+    // Act & Assert
+    expect(() => loadConfig(filePath)).toThrow(
+      `"accounts[0].name" must be a non-empty string.`,
+    );
+  });
+
+  it("throws when an account entry is missing the address field", () => {
+    // Arrange
+    const filePath = createTempConfigFile(
+      "account-no-address",
+      JSON.stringify({ accounts: [{ name: "whale_1" }] }),
+    );
+
+    // Act & Assert
+    expect(() => loadConfig(filePath)).toThrow(
+      `"accounts[0].address" must be a non-empty string.`,
+    );
+  });
+
+  it("throws when accounts_mode is invalid", () => {
+    // Arrange
+    const filePath = createTempConfigFile(
+      "invalid-mode",
+      JSON.stringify({ accounts_mode: "merge" }),
+    );
+
+    // Act & Assert
+    expect(() => loadConfig(filePath)).toThrow(
+      `"accounts_mode" must be "concatenate" or "overwrite".`,
+    );
+  });
+
+  it("throws when seed is not an integer", () => {
+    // Arrange
+    const filePath = createTempConfigFile(
+      "seed-float",
+      JSON.stringify({ seed: 1.5 }),
+    );
+
+    // Act & Assert
+    expect(() => loadConfig(filePath)).toThrow(`"seed" must be an integer.`);
+  });
+
+  it("throws when runs is not a positive integer", () => {
+    // Arrange
+    const filePath = createTempConfigFile(
+      "runs-zero",
+      JSON.stringify({ runs: 0 }),
+    );
+
+    // Act & Assert
+    expect(() => loadConfig(filePath)).toThrow(
+      `"runs" must be a positive integer.`,
+    );
+  });
+
+  it("throws when bail is not a boolean", () => {
+    // Arrange
+    const filePath = createTempConfigFile(
+      "bail-string",
+      JSON.stringify({ bail: "yes" }),
+    );
+
+    // Act & Assert
+    expect(() => loadConfig(filePath)).toThrow(`"bail" must be a boolean.`);
+  });
+});
+
+describe("Account resolution", () => {
+  const simnetAccounts = new Map([
+    ["deployer", "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"],
+    ["wallet_1", "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5"],
+    ["faucet", "STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6"],
+  ]);
+
+  it("filters out faucet when no config accounts are provided", () => {
+    // Arrange & Act
+    const { eligibleAccounts, allAddresses } = resolveAccounts(
+      simnetAccounts,
+      undefined,
+    );
+
+    // Assert
+    expect(eligibleAccounts.has("faucet")).toBe(false);
+    expect(eligibleAccounts.has("deployer")).toBe(true);
+    expect(eligibleAccounts.has("wallet_1")).toBe(true);
+    expect(allAddresses).toContain("STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6");
+  });
+
+  it("overwrites simnet accounts with config accounts by default", () => {
+    // Arrange
+    const configAccounts: ConfigAccount[] = [
+      { name: "whale_1", address: "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE" },
+    ];
+
+    // Act
+    const { eligibleAccounts, allAddresses } = resolveAccounts(
+      simnetAccounts,
+      configAccounts,
+    );
+
+    // Assert
+    expect(eligibleAccounts.size).toBe(1);
+    expect(eligibleAccounts.has("whale_1")).toBe(true);
+    expect(eligibleAccounts.has("deployer")).toBe(false);
+    expect(allAddresses).toEqual(["SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE"]);
+  });
+
+  it("overwrites simnet accounts when mode is overwrite", () => {
+    // Arrange
+    const configAccounts: ConfigAccount[] = [
+      { name: "whale_1", address: "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE" },
+    ];
+
+    // Act
+    const { eligibleAccounts, allAddresses } = resolveAccounts(
+      simnetAccounts,
+      configAccounts,
+      "overwrite",
+    );
+
+    // Assert
+    expect(eligibleAccounts.size).toBe(1);
+    expect(eligibleAccounts.has("whale_1")).toBe(true);
+    expect(eligibleAccounts.has("deployer")).toBe(false);
+    expect(allAddresses).toEqual(["SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE"]);
+  });
+
+  it("config accounts override simnet accounts with the same name when concatenating", () => {
+    // Arrange
+    const configAccounts: ConfigAccount[] = [
+      {
+        name: "wallet_1",
+        address: "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+      },
+    ];
+
+    // Act
+    const { eligibleAccounts } = resolveAccounts(
+      simnetAccounts,
+      configAccounts,
+      "concatenate",
+    );
+
+    // Assert
+    expect(eligibleAccounts.get("wallet_1")).toBe(
+      "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+    );
+  });
+
+  it("returns simnet accounts unchanged when config accounts list is empty", () => {
+    // Arrange & Act
+    const { eligibleAccounts } = resolveAccounts(simnetAccounts, []);
+
+    // Assert
+    expect(eligibleAccounts.has("deployer")).toBe(true);
+    expect(eligibleAccounts.has("wallet_1")).toBe(true);
+    expect(eligibleAccounts.has("faucet")).toBe(false);
+    expect(eligibleAccounts.size).toBe(2);
+  });
+});

--- a/config.tests.ts
+++ b/config.tests.ts
@@ -52,7 +52,7 @@ describe("Config loading and validation", () => {
     const filePath = createTempConfigFile("empty-object", "{}");
 
     // Act
-    const config = loadConfig(filePath);
+    const { config } = loadConfig(filePath);
 
     // Assert
     expect(config).toEqual({});
@@ -77,7 +77,7 @@ describe("Config loading and validation", () => {
     const filePath = createTempConfigFile("all-fields", content);
 
     // Act
-    const config = loadConfig(filePath);
+    const { config, unknownKeys } = loadConfig(filePath);
 
     // Assert
     expect(config.accounts).toEqual([
@@ -89,6 +89,22 @@ describe("Config loading and validation", () => {
     expect(config.bail).toBe(true);
     expect(config.regr).toBe(false);
     expect(config.dial).toBe("./dialers.cjs");
+    expect(unknownKeys).toEqual([]);
+  });
+
+  it("reports unrecognized keys", () => {
+    // Arrange
+    const filePath = createTempConfigFile(
+      "unknown-keys",
+      JSON.stringify({ sedd: 42, rans: 100, seed: 1 }),
+    );
+
+    // Act
+    const { config, unknownKeys } = loadConfig(filePath);
+
+    // Assert
+    expect(unknownKeys).toEqual(["sedd", "rans"]);
+    expect(config.seed).toBe(1);
   });
 
   it("throws when accounts is not an array", () => {

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,200 @@
+import { existsSync, readFileSync } from "node:fs";
+
+/**
+ * A custom account entry in the config file.
+ */
+export interface ConfigAccount {
+  /** The account name (e.g., "whale_1"). */
+  name: string;
+  /** The Stacks address (e.g., "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE"). */
+  address: string;
+}
+
+/**
+ * The mode for merging config accounts with Devnet.toml accounts.
+ * - "concatenate": Adds config accounts to the existing Devnet accounts.
+ * - "overwrite": Replaces all Devnet accounts with config accounts.
+ */
+export type AccountsMode = "concatenate" | "overwrite";
+
+/**
+ * The structure of a rendezvous config file (rv.config.json).
+ */
+export interface RendezvousConfig {
+  /** Custom accounts to use during testing. */
+  accounts?: ConfigAccount[];
+  /**
+   * How to combine config accounts with Devnet.toml accounts.
+   * Default: "overwrite".
+   */
+  accounts_mode?: AccountsMode;
+  /** Seed for replay functionality. */
+  seed?: number;
+  /** Number of test iterations. */
+  runs?: number;
+  /** Stop on first failure. */
+  bail?: boolean;
+  /** Run regression tests only. */
+  regr?: boolean;
+  /** Path to custom dialers file. */
+  dial?: string;
+}
+
+/**
+ * Loads and validates a rendezvous config file.
+ * @param configPath The path to the config file.
+ * @returns The parsed and validated config.
+ */
+export const loadConfig = (configPath: string): RendezvousConfig => {
+  if (!existsSync(configPath)) {
+    throw new Error(`Config file not found: ${configPath}`);
+  }
+
+  const raw = readFileSync(configPath, "utf-8");
+
+  let parsed: unknown = undefined;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Failed to parse config file as JSON: ${configPath}`);
+  }
+
+  return validateConfig(parsed);
+};
+
+/**
+ * Validates the parsed config object and returns a typed config.
+ * @param raw The raw parsed JSON object.
+ * @returns The validated config.
+ */
+const validateConfig = (raw: unknown): RendezvousConfig => {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new Error("Config file must contain a JSON object.");
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const config: RendezvousConfig = {};
+
+  if ("accounts" in obj) {
+    if (!Array.isArray(obj.accounts)) {
+      throw new Error(`"accounts" must be an array.`);
+    }
+    config.accounts = obj.accounts.map((entry: unknown, i: number) => {
+      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+        throw new Error(`"accounts[${i}]" must be an object.`);
+      }
+      const acc = entry as Record<string, unknown>;
+      if (typeof acc.name !== "string" || acc.name.length === 0) {
+        throw new Error(`"accounts[${i}].name" must be a non-empty string.`);
+      }
+      if (typeof acc.address !== "string" || acc.address.length === 0) {
+        throw new Error(`"accounts[${i}].address" must be a non-empty string.`);
+      }
+      return { name: acc.name, address: acc.address };
+    });
+  }
+
+  if ("accounts_mode" in obj) {
+    if (
+      obj.accounts_mode !== "concatenate" &&
+      obj.accounts_mode !== "overwrite"
+    ) {
+      throw new Error(
+        `"accounts_mode" must be "concatenate" or "overwrite". Got: "${obj.accounts_mode}".`,
+      );
+    }
+    config.accounts_mode = obj.accounts_mode;
+  }
+
+  if ("seed" in obj) {
+    if (typeof obj.seed !== "number" || !Number.isInteger(obj.seed)) {
+      throw new Error(`"seed" must be an integer.`);
+    }
+    config.seed = obj.seed;
+  }
+
+  if ("runs" in obj) {
+    if (
+      typeof obj.runs !== "number" ||
+      !Number.isInteger(obj.runs) ||
+      obj.runs < 1
+    ) {
+      throw new Error(`"runs" must be a positive integer.`);
+    }
+    config.runs = obj.runs;
+  }
+
+  if ("bail" in obj) {
+    if (typeof obj.bail !== "boolean") {
+      throw new Error(`"bail" must be a boolean.`);
+    }
+    config.bail = obj.bail;
+  }
+
+  if ("regr" in obj) {
+    if (typeof obj.regr !== "boolean") {
+      throw new Error(`"regr" must be a boolean.`);
+    }
+    config.regr = obj.regr;
+  }
+
+  if ("dial" in obj) {
+    if (typeof obj.dial !== "string") {
+      throw new Error(`"dial" must be a string.`);
+    }
+    config.dial = obj.dial;
+  }
+
+  return config;
+};
+
+/**
+ * Resolves accounts by merging config accounts with simnet accounts.
+ * @param simnetAccounts The accounts from the simnet (Devnet.toml).
+ * @param configAccounts The custom accounts from the config file.
+ * @param mode The merge mode: "overwrite" (default) or "concatenate".
+ * @returns An object with the resolved eligible accounts map and all addresses.
+ */
+export const resolveAccounts = (
+  simnetAccounts: Map<string, string>,
+  configAccounts: ConfigAccount[] | undefined,
+  mode: AccountsMode = "overwrite",
+): { eligibleAccounts: Map<string, string>; allAddresses: string[] } => {
+  if (!configAccounts || configAccounts.length === 0) {
+    // No custom accounts — use simnet accounts, filtering out "faucet".
+    const eligibleAccounts = new Map(
+      [...simnetAccounts].filter(([key]) => key !== "faucet"),
+    );
+    return {
+      eligibleAccounts,
+      allAddresses: [...simnetAccounts.values()],
+    };
+  }
+
+  const configAccountsMap = new Map(
+    configAccounts.map((acc) => [acc.name, acc.address]),
+  );
+
+  if (mode === "overwrite") {
+    // Replace all simnet accounts with config accounts.
+    return {
+      eligibleAccounts: new Map(configAccountsMap),
+      allAddresses: [...configAccountsMap.values()],
+    };
+  }
+
+  // Concatenate: start with simnet accounts (filtering out "faucet"),
+  // then add/override with config accounts.
+  const merged = new Map(
+    [...simnetAccounts].filter(([key]) => key !== "faucet"),
+  );
+
+  for (const [name, address] of configAccountsMap) {
+    merged.set(name, address);
+  }
+
+  // All addresses includes simnet addresses plus any new config addresses.
+  const allAddresses = [...merged.values()];
+
+  return { eligibleAccounts: merged, allAddresses };
+};

--- a/config.ts
+++ b/config.ts
@@ -193,7 +193,8 @@ export const resolveAccounts = (
     merged.set(name, address);
   }
 
-  // All addresses includes simnet addresses plus any new config addresses.
+  // All addresses includes simnet addresses excluding faucet plus any new
+  // user-provided config addresses.
   const allAddresses = [...merged.values()];
 
   return { eligibleAccounts: merged, allAddresses };

--- a/config.ts
+++ b/config.ts
@@ -45,7 +45,9 @@ export interface RendezvousConfig {
  * @param configPath The path to the config file.
  * @returns The parsed and validated config.
  */
-export const loadConfig = (configPath: string): RendezvousConfig => {
+export const loadConfig = (
+  configPath: string,
+): { config: RendezvousConfig; unknownKeys: string[] } => {
   if (!existsSync(configPath)) {
     throw new Error(`Config file not found: ${configPath}`);
   }
@@ -67,7 +69,9 @@ export const loadConfig = (configPath: string): RendezvousConfig => {
  * @param raw The raw parsed JSON object.
  * @returns The validated config.
  */
-const validateConfig = (raw: unknown): RendezvousConfig => {
+const validateConfig = (
+  raw: unknown,
+): { config: RendezvousConfig; unknownKeys: string[] } => {
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
     throw new Error("Config file must contain a JSON object.");
   }
@@ -145,7 +149,18 @@ const validateConfig = (raw: unknown): RendezvousConfig => {
     config.dial = obj.dial;
   }
 
-  return config;
+  const knownKeys = new Set([
+    "accounts",
+    "accounts_mode",
+    "seed",
+    "runs",
+    "bail",
+    "regr",
+    "dial",
+  ]);
+  const unknownKeys = Object.keys(obj).filter((k) => !knownKeys.has(k));
+
+  return { config, unknownKeys };
 };
 
 /**

--- a/docs/chapter_6.md
+++ b/docs/chapter_6.md
@@ -45,7 +45,7 @@ This chapter explains how to use Rendezvous in different situations. By the end,
 To run Rendezvous, use the following command:
 
 ```bash
-rv <path-to-clarinet-project> <contract-name> <type> [--seed] [--runs] [--regr] [--bail] [--dial]
+rv <path-to-clarinet-project> <contract-name> <type> [--config] [--seed] [--runs] [--regr] [--bail] [--dial]
 ```
 
 Let's break down each part of the command.
@@ -354,6 +354,46 @@ rm .rendezvous-regressions/ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.counter.jso
 
 You can also manually edit the regression file to remove specific failures while keeping others.
 
+**6. Using a Config File**
+
+Instead of passing options as CLI flags, you can provide a JSON config file with `--config`. When a config file is used, all run options come from the file exclusively — CLI flags like `--seed` or `--runs` are ignored.
+
+```bash
+rv root contract test --config=rv.config.json
+```
+
+A config file is a JSON object with optional fields:
+
+```json
+{
+  "accounts": [
+    {
+      "name": "whale_1",
+      "address": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE"
+    }
+  ],
+  "accounts_mode": "overwrite",
+  "seed": 42,
+  "runs": 500,
+  "bail": true,
+  "dial": "./sip010.cjs"
+}
+```
+
+| Field           | Type             | Description                                             |
+| --------------- | ---------------- | ------------------------------------------------------- |
+| `accounts`      | array of objects | Custom accounts (`name` and `address` fields required). |
+| `accounts_mode` | string           | `"overwrite"` (default) or `"concatenate"`.             |
+| `seed`          | integer          | Seed for replay functionality.                          |
+| `runs`          | positive integer | Number of test iterations.                              |
+| `bail`          | boolean          | Stop on first failure.                                  |
+| `regr`          | boolean          | Run regression tests only.                              |
+| `dial`          | string           | Path to custom dialers file.                            |
+
+The `accounts` field lets you define custom accounts for testing. By default (`"overwrite"` mode), these replace the Devnet.toml accounts entirely. With `"concatenate"` mode, config accounts are merged with the existing Devnet accounts — if a name appears in both, the config account's address takes precedence.
+
+Rendezvous warns if the config file contains unrecognized keys (e.g. a typo like `"sedd"` instead of `"seed"`), and also warns if CLI flags are passed alongside `--config`.
+
 ### Summary
 
 | Argument/Option              | Description                                                                      | Example                                           |
@@ -364,7 +404,9 @@ You can also manually edit the regression file to remove specific failures while
 | `--runs=<num>`               | Sets the number of test iterations (default: 100).                               | `rv root contract test --runs=500`                |
 | `--seed=<num>`               | Uses a specific seed for reproducibility.                                        | `rv root contract test --seed=12345`              |
 | `--regr`                     | Run regression tests only (replay saved failures).                               | `rv root contract test --regr`                    |
+| `--bail`                     | Stop after the first failure.                                                    | `rv root contract test --bail`                    |
 | `--dial=<file>`              | Loads JavaScript dialers from a file for pre/post-processing.                    | `rv root contract test --dial=./custom-dialer.js` |
+| `--config=<file>`            | Uses a JSON config file for all run options.                                     | `rv root contract test --config=rv.config.json`   |
 
 ---
 

--- a/example/rv.config.json
+++ b/example/rv.config.json
@@ -1,0 +1,15 @@
+{
+  "accounts": [
+    {
+      "name": "whale_1",
+      "address": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE"
+    },
+    {
+      "name": "whale_2",
+      "address": "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
+    }
+  ],
+  "accounts_mode": "overwrite",
+  "runs": 500,
+  "bail": true
+}

--- a/invariant.ts
+++ b/invariant.ts
@@ -48,6 +48,8 @@ import type { ImplementedTraitType } from "./traits.types";
  * shrinking.
  * @param regr Whether to run regression tests only.
  * @param radio The custom logging event emitter.
+ * @param eligibleAccounts The resolved eligible accounts map.
+ * @param allAddresses All resolved addresses for principal type generation.
  * @returns void
  */
 export const checkInvariants = async (
@@ -61,6 +63,8 @@ export const checkInvariants = async (
   bail: boolean,
   regr: boolean,
   radio: EventEmitter,
+  eligibleAccounts: Map<string, string>,
+  allAddresses: string[],
 ) => {
   // The Rendezvous identifier is the first one in the list. Only one contract
   // can be fuzzed at a time.
@@ -239,6 +243,8 @@ export const checkInvariants = async (
         bail,
         dial: regression.dial,
         radio,
+        eligibleAccounts,
+        allAddresses,
         functions,
         invariants,
         projectTraitImplementations,
@@ -260,6 +266,8 @@ export const checkInvariants = async (
       bail,
       dial,
       radio,
+      eligibleAccounts,
+      allAddresses,
       functions,
       invariants,
       projectTraitImplementations,
@@ -279,6 +287,8 @@ interface InvariantTestConfig {
   bail: boolean;
   dial: string | undefined;
   radio: EventEmitter;
+  eligibleAccounts: Map<string, string>;
+  allAddresses: string[];
 }
 
 /**
@@ -311,17 +321,12 @@ const invariantTest = async (
     bail,
     dial,
     radio,
+    eligibleAccounts,
+    allAddresses,
     functions,
     invariants,
     projectTraitImplementations,
   } = config;
-
-  // Derive accounts and addresses from simnet.
-  const simnetAccounts = simnet.getAccounts();
-  const eligibleAccounts = new Map(
-    [...simnetAccounts].filter(([key]) => key !== "faucet"),
-  );
-  const simnetAddresses = [...simnetAccounts.values()];
 
   /**
    * The dialer registry, which is used to keep track of all the custom dialers
@@ -408,7 +413,7 @@ const invariantTest = async (
                   fc.tuple(
                     ...functionToArbitrary(
                       selectedFunction,
-                      simnetAddresses,
+                      allAddresses,
                       projectTraitImplementations,
                     ),
                   ),
@@ -417,7 +422,7 @@ const invariantTest = async (
               invariantArgs: fc.tuple(
                 ...functionToArbitrary(
                   r.selectedInvariant,
-                  simnetAddresses,
+                  allAddresses,
                   projectTraitImplementations,
                 ),
               ),

--- a/property.ts
+++ b/property.ts
@@ -45,6 +45,8 @@ import type { ImplementedTraitType } from "./traits.types";
  * shrinking.
  * @param regr Whether to run regression tests only.
  * @param radio The custom logging event emitter.
+ * @param eligibleAccounts The resolved eligible accounts map (name to address).
+ * @param allAddresses All resolved addresses for principal type generation.
  * @returns void
  */
 export const checkProperties = async (
@@ -57,6 +59,8 @@ export const checkProperties = async (
   bail: boolean,
   regr: boolean,
   radio: EventEmitter,
+  eligibleAccounts: Map<string, string>,
+  allAddresses: string[],
 ) => {
   // A map where the keys are the test contract identifiers and the values are
   // arrays of their test functions. This map will be used to access the test
@@ -237,6 +241,8 @@ export const checkProperties = async (
         seed: regression.seed,
         bail,
         radio,
+        eligibleAccounts,
+        allAddresses,
         testFunctions,
         projectTraitImplementations,
         testContractsPairedFunctions,
@@ -257,6 +263,8 @@ export const checkProperties = async (
       seed,
       bail,
       radio,
+      eligibleAccounts,
+      allAddresses,
       testFunctions,
       projectTraitImplementations,
       testContractsPairedFunctions,
@@ -275,6 +283,8 @@ interface PropertyTestConfig {
   seed: number | undefined;
   bail: boolean;
   radio: EventEmitter;
+  eligibleAccounts: Map<string, string>;
+  allAddresses: string[];
 }
 
 /**
@@ -306,17 +316,12 @@ const propertyTest = async (
     seed,
     bail,
     radio,
+    eligibleAccounts,
+    allAddresses,
     testFunctions,
     projectTraitImplementations,
     testContractsPairedFunctions,
   } = config;
-
-  // Derive accounts and addresses from simnet.
-  const simnetAccounts = simnet.getAccounts();
-  const eligibleAccounts = new Map(
-    [...simnetAccounts].filter(([key]) => key !== "faucet"),
-  );
-  const simnetAddresses = [...simnetAccounts.values()];
 
   const statistics: Statistics = {
     test: {
@@ -371,7 +376,7 @@ const propertyTest = async (
               functionArgs: fc.tuple(
                 ...functionToArbitrary(
                   r.selectedTestFunction,
-                  simnetAddresses,
+                  allAddresses,
                   projectTraitImplementations,
                 ),
               ),


### PR DESCRIPTION
This PR:
- decouples run configuration parsing from `main` to keep the entry point clean
- adds a `--config` flag for file-based configuration
- adds support for pre-specifying custom accounts (allowing mainnet addresses to be used without providing their private keys by leveraging simnet remote data) using the config file

Fixes #183.