### PR TITLE
Expose property-based testing helpers as public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ fc.assert(
 ```
 
 - `getContractFunction(simnet, contract, fn, deployer?)` — retrieves a function interface, enriched with trait data.
-- `strategyFor(simnet, fn)` — returns an `fc.Arbitrary<ClarityValue[]>` ready for use with `simnet.callPublicFn` or `simnet.callReadOnlyFn`.
+- `strategyFor(simnet, fn, allAddresses?, projectTraitImplementations?)` — returns an `fc.Arbitrary<ClarityValue[]>` ready for use with `simnet.callPublicFn` or `simnet.callReadOnlyFn`. `allAddresses` restricts the principal pool (defaults to every account in the simnet); `projectTraitImplementations` reuses a precomputed trait map (defaults to extracting it from the simnet).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,37 @@ rv example counter invariant
 
 ---
 
+### Library API
+
+Rendezvous also works as a library for building custom property-based testing strategies. It handles the hard part — generating valid random Clarity arguments for any function signature, including recursive types, trait references, and custom accounts.
+
+```ts
+import { initSimnet } from "@stacks/clarinet-sdk";
+import { getContractFunction, strategyFor } from "@stacks/rendezvous";
+import fc from "fast-check";
+
+const simnet = await initSimnet("./Clarinet.toml");
+const add = getContractFunction(simnet, "counter", "add");
+const arb = strategyFor(add, simnet);
+
+fc.assert(
+  fc.asyncProperty(arb, (args) => {
+    const { result } = simnet.callPublicFn(
+      `${simnet.deployer}.counter`,
+      "add",
+      args,
+      simnet.deployer,
+    );
+    return result.type !== "err";
+  }),
+);
+```
+
+- `getContractFunction(simnet, contract, fn, deployer?)` — retrieves a function interface, enriched with trait data.
+- `strategyFor(fn, simnet)` — returns an `fc.Arbitrary<ClarityValue[]>` ready for use with `simnet.callPublicFn` or `simnet.callReadOnlyFn`.
+
+---
+
 ### Documentation
 
 For full documentation, see the official [Rendezvous Book](https://stacks-network.github.io/rendezvous/).

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ import fc from "fast-check";
 
 const simnet = await initSimnet("./Clarinet.toml");
 const add = getContractFunction(simnet, "counter", "add");
-const arb = strategyFor(add, simnet);
+const arb = strategyFor(simnet, add);
 
 fc.assert(
-  fc.asyncProperty(arb, (args) => {
+  fc.property(arb, (args) => {
     const { result } = simnet.callPublicFn(
       `${simnet.deployer}.counter`,
       "add",
@@ -135,7 +135,7 @@ fc.assert(
 ```
 
 - `getContractFunction(simnet, contract, fn, deployer?)` — retrieves a function interface, enriched with trait data.
-- `strategyFor(fn, simnet)` — returns an `fc.Arbitrary<ClarityValue[]>` ready for use with `simnet.callPublicFn` or `simnet.callReadOnlyFn`.
+- `strategyFor(simnet, fn)` — returns an `fc.Arbitrary<ClarityValue[]>` ready for use with `simnet.callPublicFn` or `simnet.callReadOnlyFn`.
 
 ---
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,6 +19,7 @@
 - [Installation](chapter_5.md)
 - [Usage](chapter_6.md)
 - [Quickstart Tutorial](chapter_7.md)
+- [Library API](chapter_9.md)
 
 # Examples
 

--- a/docs/chapter_2.md
+++ b/docs/chapter_2.md
@@ -7,6 +7,8 @@ The tool focuses on two primary testing methodologies:
 1. **Property-based testing**: Verifying that specific properties of your contract hold true across a wide range of possible inputs.
 2. **Invariant testing**: Ensuring that certain conditions about your contract's state remain true regardless of the sequence of operations performed.
 
+Rendezvous can be used in two ways: through the `rv` CLI (the primary interface covered throughout most of this book) or as a TypeScript library for composing custom property-based tests with full control over the testing loop. See the [Library API](chapter_9.md) chapter for details.
+
 ## Why You Need Rendezvous
 
 Smart contracts are immutable once deployed, making post-deployment fixes expensive or impossible. Traditional testing methods often fall short in discovering edge cases that might lead to security vulnerabilities or unexpected behavior. Rendezvous addresses these challenges by:
@@ -41,4 +43,4 @@ root
 
 This structure allows for a natural workflow where tests live close to the code they're testing, making it easier to maintain both in tandem.
 
-In the following chapters, we'll explore why testing directly in Clarity is beneficial, the testing methodologies employed by Rendezvous, how to install and use the tool, and examples of effective testing patterns.
+In the following chapters, we'll explore why testing directly in Clarity is beneficial, the testing methodologies employed by Rendezvous, how to install and use the tool, how to consume it as a library, and examples of effective testing patterns.

--- a/docs/chapter_5.md
+++ b/docs/chapter_5.md
@@ -195,3 +195,5 @@ If you installed from source:
 ## Next Steps
 
 Now that you have Rendezvous installed, you're ready to start testing your Clarity contracts. In the next chapter, we'll cover how to use Rendezvous effectively with detailed usage examples.
+
+If you'd rather drive the testing loop yourself from TypeScript — composing custom fast-check properties on top of Rendezvous's argument generation — see the [Library API](chapter_9.md) chapter.

--- a/docs/chapter_9.md
+++ b/docs/chapter_9.md
@@ -20,18 +20,18 @@ Retrieves a function interface from a deployed contract. The returned interface 
 
 **Parameters:**
 
-| Parameter      | Type     | Description                                       |
-| -------------- | -------- | ------------------------------------------------- |
-| `simnet`       | `Simnet` | The simnet instance from `initSimnet`.             |
-| `contractName` | `string` | The contract name (e.g., `"counter"`).             |
-| `functionName` | `string` | The function name (e.g., `"increment"`).           |
+| Parameter      | Type     | Description                                                |
+| -------------- | -------- | ---------------------------------------------------------- |
+| `simnet`       | `Simnet` | The simnet instance from `initSimnet`.                     |
+| `contractName` | `string` | The contract name (e.g., `"counter"`).                     |
+| `functionName` | `string` | The function name (e.g., `"increment"`).                   |
 | `deployer`     | `string` | Optional. Deployer address. Defaults to `simnet.deployer`. |
 
 **Returns:** `EnrichedContractInterfaceFunction`
 
 **Throws** if the contract or function is not found.
 
-### `strategyFor(fn, simnet)`
+### `strategyFor(simnet, fn)`
 
 Returns a fast-check arbitrary that produces `ClarityValue[]` arrays — ready for use with `simnet.callPublicFn` or `simnet.callReadOnlyFn`.
 
@@ -39,10 +39,10 @@ Handles all Clarity types automatically: `uint`, `int`, `bool`, `principal`, `bu
 
 **Parameters:**
 
-| Parameter | Type                                 | Description                                   |
-| --------- | ------------------------------------ | --------------------------------------------- |
-| `fn`      | `EnrichedContractInterfaceFunction`  | Function interface from `getContractFunction`. |
-| `simnet`  | `Simnet`                             | The simnet instance.                           |
+| Parameter | Type                                | Description                                    |
+| --------- | ----------------------------------- | ---------------------------------------------- |
+| `simnet`  | `Simnet`                            | The simnet instance.                           |
+| `fn`      | `EnrichedContractInterfaceFunction` | Function interface from `getContractFunction`. |
 
 **Returns:** `fc.Arbitrary<ClarityValue[]>`
 
@@ -51,16 +51,16 @@ Principal addresses and trait implementations are resolved from the simnet autom
 ## Example
 
 ```ts
-import fc from "fast-check";
 import { initSimnet } from "@stacks/clarinet-sdk";
 import { getContractFunction, strategyFor } from "@stacks/rendezvous";
+import fc from "fast-check";
 
 const simnet = await initSimnet("./Clarinet.toml");
 const add = getContractFunction(simnet, "counter", "add");
-const arb = strategyFor(add, simnet);
+const arb = strategyFor(simnet, add);
 
 fc.assert(
-  fc.asyncProperty(arb, async (args) => {
+  fc.property(arb, (args) => {
     const { result } = simnet.callPublicFn(
       `${simnet.deployer}.counter`,
       "add",
@@ -86,23 +86,23 @@ For functions that take no parameters, `strategyFor` returns an arbitrary produc
 
 ```ts
 const increment = getContractFunction(simnet, "counter", "increment");
-const arb = strategyFor(increment, simnet);
+const arb = strategyFor(simnet, increment);
 // arb always produces [].
 ```
 
 ## Supported Clarity Types
 
-| Clarity Type     | Generated As                                      |
-| ---------------- | ------------------------------------------------- |
-| `uint`           | Natural numbers                                   |
-| `int`            | Integers                                          |
-| `bool`           | Booleans                                          |
-| `principal`      | Random address from simnet accounts               |
-| `buff`           | Hex-encoded buffers (respects max length)          |
-| `string-ascii`   | ASCII strings (respects max length)                |
-| `string-utf8`    | UTF-8 strings (respects max length)                |
-| `list`           | Arrays of the element type (recursive)             |
-| `tuple`          | Records with named fields (recursive)              |
-| `optional`       | `none` or `some` of the wrapped type (recursive)   |
-| `response`       | `ok` or `error` branch (recursive)                 |
-| `trait_reference` | Random contract implementing the trait             |
+| Clarity Type      | Generated As                                     |
+| ----------------- | ------------------------------------------------ |
+| `uint`            | Natural numbers                                  |
+| `int`             | Integers                                         |
+| `bool`            | Booleans                                         |
+| `principal`       | Random address from simnet accounts              |
+| `buff`            | Hex-encoded buffers (respects max length)        |
+| `string-ascii`    | ASCII strings (respects max length)              |
+| `string-utf8`     | UTF-8 strings (respects max length)              |
+| `list`            | Arrays of the element type (recursive)           |
+| `tuple`           | Records with named fields (recursive)            |
+| `optional`        | `none` or `some` of the wrapped type (recursive) |
+| `response`        | `ok` or `error` branch (recursive)               |
+| `trait_reference` | Random contract implementing the trait           |

--- a/docs/chapter_9.md
+++ b/docs/chapter_9.md
@@ -31,7 +31,7 @@ Retrieves a function interface from a deployed contract. The returned interface 
 
 **Throws** if the contract or function is not found.
 
-### `strategyFor(simnet, fn)`
+### `strategyFor(simnet, fn, allAddresses?, projectTraitImplementations?)`
 
 Returns a fast-check arbitrary that produces `ClarityValue[]` arrays — ready for use with `simnet.callPublicFn` or `simnet.callReadOnlyFn`.
 
@@ -39,14 +39,16 @@ Handles all Clarity types automatically: `uint`, `int`, `bool`, `principal`, `bu
 
 **Parameters:**
 
-| Parameter | Type                                | Description                                    |
-| --------- | ----------------------------------- | ---------------------------------------------- |
-| `simnet`  | `Simnet`                            | The simnet instance.                           |
-| `fn`      | `EnrichedContractInterfaceFunction` | Function interface from `getContractFunction`. |
+| Parameter                     | Type                                     | Description                                                                                                              |
+| ----------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `simnet`                      | `Simnet`                                 | The simnet instance.                                                                                                     |
+| `fn`                          | `EnrichedContractInterfaceFunction`      | Function interface from `getContractFunction`.                                                                           |
+| `allAddresses`                | `string[]`                               | Optional. Addresses used for principal-typed argument generation. Defaults to every account in the simnet.               |
+| `projectTraitImplementations` | `Record<string, ImplementedTraitType[]>` | Optional. Project/requirement contracts keyed by the traits they implement. Defaults to extracting them from the simnet. |
 
 **Returns:** `fc.Arbitrary<ClarityValue[]>`
 
-Principal addresses and trait implementations are resolved from the simnet automatically.
+When neither override is supplied, principal addresses and trait implementations are resolved from the simnet automatically. Pass `allAddresses` to restrict the principal pool (for example, to a user-filtered account set), and `projectTraitImplementations` to reuse a precomputed map when calling `strategyFor` repeatedly.
 
 ## Example
 
@@ -89,6 +91,20 @@ const increment = getContractFunction(simnet, "counter", "increment");
 const arb = strategyFor(simnet, increment);
 // arb always produces [].
 ```
+
+## Restricting the Principal Pool
+
+When a function takes a `principal` argument, `strategyFor` draws from every account in the simnet by default. Pass `allAddresses` to restrict that pool:
+
+```ts
+const mint = getContractFunction(simnet, "rendezvous-token", "mint");
+const [wallet1] = [...simnet.getAccounts().values()];
+
+const arb = strategyFor(simnet, mint, [wallet1]);
+// Every generated `recipient` is wallet1.
+```
+
+`projectTraitImplementations` can be overridden the same way, which is useful when you already have the trait map computed and want to avoid re-extracting it on each call.
 
 ## Supported Clarity Types
 

--- a/docs/chapter_9.md
+++ b/docs/chapter_9.md
@@ -1,0 +1,108 @@
+# Library API
+
+Rendezvous can be used as a library for building custom property-based testing strategies in TypeScript. Instead of relying solely on the `rv` CLI, you can import its argument generation capabilities directly and compose your own [fast-check](https://github.com/dubzzz/fast-check) properties.
+
+This is useful when you need full control over the testing loop: custom assertions, stateful setups, multi-contract interactions, or integration with existing test frameworks like Vitest or Jest.
+
+## Installation
+
+```bash
+npm install @stacks/rendezvous
+```
+
+Rendezvous ships with TypeScript declarations. You also need `fast-check` and `@stacks/clarinet-sdk` (both are already dependencies).
+
+## API
+
+### `getContractFunction(simnet, contractName, functionName, deployer?)`
+
+Retrieves a function interface from a deployed contract. The returned interface is enriched with trait reference data when applicable.
+
+**Parameters:**
+
+| Parameter      | Type     | Description                                       |
+| -------------- | -------- | ------------------------------------------------- |
+| `simnet`       | `Simnet` | The simnet instance from `initSimnet`.             |
+| `contractName` | `string` | The contract name (e.g., `"counter"`).             |
+| `functionName` | `string` | The function name (e.g., `"increment"`).           |
+| `deployer`     | `string` | Optional. Deployer address. Defaults to `simnet.deployer`. |
+
+**Returns:** `EnrichedContractInterfaceFunction`
+
+**Throws** if the contract or function is not found.
+
+### `strategyFor(fn, simnet)`
+
+Returns a fast-check arbitrary that produces `ClarityValue[]` arrays — ready for use with `simnet.callPublicFn` or `simnet.callReadOnlyFn`.
+
+Handles all Clarity types automatically: `uint`, `int`, `bool`, `principal`, `buff`, `string-ascii`, `string-utf8`, `list`, `tuple`, `optional`, `response`, and `trait_reference` (including recursive/nested structures like list of tuples or optional of response).
+
+**Parameters:**
+
+| Parameter | Type                                 | Description                                   |
+| --------- | ------------------------------------ | --------------------------------------------- |
+| `fn`      | `EnrichedContractInterfaceFunction`  | Function interface from `getContractFunction`. |
+| `simnet`  | `Simnet`                             | The simnet instance.                           |
+
+**Returns:** `fc.Arbitrary<ClarityValue[]>`
+
+Principal addresses and trait implementations are resolved from the simnet automatically.
+
+## Example
+
+```ts
+import fc from "fast-check";
+import { initSimnet } from "@stacks/clarinet-sdk";
+import { getContractFunction, strategyFor } from "@stacks/rendezvous";
+
+const simnet = await initSimnet("./Clarinet.toml");
+const add = getContractFunction(simnet, "counter", "add");
+const arb = strategyFor(add, simnet);
+
+fc.assert(
+  fc.asyncProperty(arb, async (args) => {
+    const { result } = simnet.callPublicFn(
+      `${simnet.deployer}.counter`,
+      "add",
+      args,
+      simnet.deployer,
+    );
+    return result.type !== "err";
+  }),
+);
+```
+
+## Custom Deployer
+
+If the contract is deployed by an address other than the default deployer, pass it explicitly:
+
+```ts
+const fn = getContractFunction(simnet, "my-contract", "my-fn", "ST1OTHER...");
+```
+
+## Functions With No Arguments
+
+For functions that take no parameters, `strategyFor` returns an arbitrary producing empty arrays:
+
+```ts
+const increment = getContractFunction(simnet, "counter", "increment");
+const arb = strategyFor(increment, simnet);
+// arb always produces [].
+```
+
+## Supported Clarity Types
+
+| Clarity Type     | Generated As                                      |
+| ---------------- | ------------------------------------------------- |
+| `uint`           | Natural numbers                                   |
+| `int`            | Integers                                          |
+| `bool`           | Booleans                                          |
+| `principal`      | Random address from simnet accounts               |
+| `buff`           | Hex-encoded buffers (respects max length)          |
+| `string-ascii`   | ASCII strings (respects max length)                |
+| `string-utf8`    | UTF-8 strings (respects max length)                |
+| `list`           | Arrays of the element type (recursive)             |
+| `tuple`          | Records with named fields (recursive)              |
+| `optional`       | `none` or `some` of the wrapped type (recursive)   |
+| `response`       | `ok` or `error` branch (recursive)                 |
+| `trait_reference` | Random contract implementing the trait             |

--- a/heatstroke.tests.ts
+++ b/heatstroke.tests.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path";
 
 import { initSimnet } from "@stacks/clarinet-sdk";
 import type { ContractInterfaceFunction } from "@stacks/clarinet-sdk-wasm";
+import { Cl, cvToString, type ClarityValue } from "@stacks/transactions";
 import fc from "fast-check";
 
 import { reporter } from "./heatstroke";
@@ -21,6 +22,13 @@ const asciiString = () =>
     ),
     minLength: 1,
   });
+
+const clarityStringUintBoolArg = () =>
+  fc.oneof(
+    asciiString().map((s) => Cl.stringAscii(s)),
+    fc.nat().map((n) => Cl.uint(n)),
+    fc.boolean().map((b) => Cl.bool(b)),
+  );
 
 describe("Custom reporter logging", () => {
   it("handles cases with missing path on failure for invariant testing type", async () => {
@@ -487,9 +495,7 @@ describe("Custom reporter logging", () => {
             outputs: fc.array(asciiString()),
             args: fc.anything(),
           }),
-          functionArgs: fc.array(
-            fc.oneof(asciiString(), fc.nat(), fc.boolean()),
-          ),
+          functionArgs: fc.array(clarityStringUintBoolArg()),
           errorMessage: asciiString(),
           clarityError: asciiString(),
           testCaller: fc.constantFrom(
@@ -509,7 +515,7 @@ describe("Custom reporter logging", () => {
             outputs: string[];
             args: any;
           };
-          functionArgs: (string | number | boolean)[];
+          functionArgs: ClarityValue[];
           errorMessage: string;
           clarityError: string;
           testCaller: [string, string];
@@ -550,7 +556,9 @@ describe("Custom reporter logging", () => {
               rendezvousContractId,
             )}`,
             `- Test Function : ${r.selectedTestFunction.name} (${r.selectedTestFunction.access})`,
-            `- Arguments     : ${JSON.stringify(r.functionArgs)}`,
+            `- Arguments     : ${r.functionArgs
+              .map((cv) => cvToString(cv))
+              .join(" ")}`,
             `- Caller        : ${r.testCaller[0]}`,
             `- Outputs       : ${JSON.stringify(
               r.selectedTestFunction.outputs,
@@ -601,9 +609,7 @@ describe("Custom reporter logging", () => {
             outputs: fc.array(asciiString()),
             args: fc.anything(),
           }),
-          functionArgs: fc.array(
-            fc.oneof(asciiString(), fc.nat(), fc.boolean()),
-          ),
+          functionArgs: fc.array(clarityStringUintBoolArg()),
           errorMessage: asciiString(),
           clarityError: asciiString(),
           testCaller: fc.constantFrom(
@@ -624,7 +630,7 @@ describe("Custom reporter logging", () => {
             outputs: string[];
             args: any;
           };
-          functionArgs: (string | number | boolean)[];
+          functionArgs: ClarityValue[];
           errorMessage: string;
           clarityError: string;
           testCaller: [string, string];
@@ -667,7 +673,9 @@ describe("Custom reporter logging", () => {
               rendezvousContractId,
             )}`,
             `- Test Function : ${r.selectedTestFunction.name} (${r.selectedTestFunction.access})`,
-            `- Arguments     : ${JSON.stringify(r.functionArgs)}`,
+            `- Arguments     : ${r.functionArgs
+              .map((cv) => cvToString(cv))
+              .join(" ")}`,
             `- Caller        : ${r.testCaller[0]}`,
             `- Outputs       : ${JSON.stringify(
               r.selectedTestFunction.outputs,

--- a/heatstroke.tests.ts
+++ b/heatstroke.tests.ts
@@ -58,7 +58,7 @@ describe("Custom reporter logging", () => {
             }),
           ),
           selectedFunctionsArgsList: fc.tuple(
-            fc.array(fc.oneof(asciiString(), fc.nat(), fc.boolean())),
+            fc.array(clarityStringUintBoolArg()),
           ),
           selectedInvariant: fc.record({
             name: asciiString(),
@@ -66,9 +66,7 @@ describe("Custom reporter logging", () => {
             outputs: fc.array(asciiString()),
             args: fc.anything(),
           }),
-          invariantArgs: fc.array(
-            fc.oneof(asciiString(), fc.nat(), fc.boolean()),
-          ),
+          invariantArgs: fc.array(clarityStringUintBoolArg()),
           errorMessage: asciiString(),
           clarityError: asciiString(),
           sutCallers: fc.array(
@@ -95,14 +93,14 @@ describe("Custom reporter logging", () => {
             outputs: string[];
             args: any;
           }[];
-          selectedFunctionsArgsList: (string | number | boolean)[][];
+          selectedFunctionsArgsList: ClarityValue[][];
           selectedInvariant: {
             name: string;
             access: string;
             outputs: string[];
             args: any;
           };
-          invariantArgs: (string | number | boolean)[];
+          invariantArgs: ClarityValue[];
           errorMessage: string;
           clarityError: string;
           sutCallers: [string, string][];
@@ -154,7 +152,7 @@ describe("Custom reporter logging", () => {
               .join(", ")})`,
             `- Arguments: ${r.selectedFunctionsArgsList
               .map((selectedFunctionArgs) =>
-                JSON.stringify(selectedFunctionArgs),
+                selectedFunctionArgs.map((cv) => cvToString(cv)).join(" "),
               )
               .join(", ")}`,
             `- Callers  : ${r.sutCallers
@@ -166,7 +164,9 @@ describe("Custom reporter logging", () => {
               )
               .join(", ")}`,
             `- Invariant: ${r.selectedInvariant.name} (${r.selectedInvariant.access})`,
-            `- Arguments: ${JSON.stringify(r.invariantArgs)}`,
+            `- Arguments: ${r.invariantArgs
+              .map((cv) => cvToString(cv))
+              .join(" ")}`,
             `- Caller   : ${r.invariantCaller[0]}`,
             `\nWhat happened? Rendezvous went on a rampage and found a weak spot:\n`,
             `The invariant "${
@@ -217,7 +217,7 @@ describe("Custom reporter logging", () => {
             }),
           ),
           selectedFunctionsArgsList: fc.tuple(
-            fc.array(fc.oneof(asciiString(), fc.nat(), fc.boolean())),
+            fc.array(clarityStringUintBoolArg()),
           ),
           selectedInvariant: fc.record({
             name: asciiString(),
@@ -225,9 +225,7 @@ describe("Custom reporter logging", () => {
             outputs: fc.array(asciiString()),
             args: fc.anything(),
           }),
-          invariantArgs: fc.array(
-            fc.oneof(asciiString(), fc.nat(), fc.boolean()),
-          ),
+          invariantArgs: fc.array(clarityStringUintBoolArg()),
           errorMessage: asciiString(),
           clarityError: asciiString(),
           sutCallers: fc.array(
@@ -255,14 +253,14 @@ describe("Custom reporter logging", () => {
             outputs: string[];
             args: any;
           }[];
-          selectedFunctionsArgsList: (string | number | boolean)[][];
+          selectedFunctionsArgsList: ClarityValue[][];
           selectedInvariant: {
             name: string;
             access: string;
             outputs: string[];
             args: any;
           };
-          invariantArgs: (string | number | boolean)[];
+          invariantArgs: ClarityValue[];
           errorMessage: string;
           clarityError: string;
           sutCallers: [string, string][];
@@ -316,7 +314,7 @@ describe("Custom reporter logging", () => {
               .join(", ")})`,
             `- Arguments: ${r.selectedFunctionsArgsList
               .map((selectedFunctionArgs) =>
-                JSON.stringify(selectedFunctionArgs),
+                selectedFunctionArgs.map((cv) => cvToString(cv)).join(" "),
               )
               .join(", ")}`,
             `- Callers  : ${r.sutCallers
@@ -328,7 +326,9 @@ describe("Custom reporter logging", () => {
               )
               .join(", ")}`,
             `- Invariant: ${r.selectedInvariant.name} (${r.selectedInvariant.access})`,
-            `- Arguments: ${JSON.stringify(r.invariantArgs)}`,
+            `- Arguments: ${r.invariantArgs
+              .map((cv) => cvToString(cv))
+              .join(" ")}`,
             `- Caller   : ${r.invariantCaller[0]}`,
             `\nWhat happened? Rendezvous went on a rampage and found a weak spot:\n`,
             `The invariant "${

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -87,8 +87,8 @@ export const reporter = (
         radio.emit(
           "logFailure",
           `- Arguments: ${ce.selectedFunctionsArgsList
-            .map((selectedFunctionArgs: any[]) =>
-              JSON.stringify(selectedFunctionArgs),
+            .map((selectedFunctionArgs: ClarityValue[]) =>
+              selectedFunctionArgs.map((cv) => cvToString(cv)).join(" "),
             )
             .join(", ")}`,
         );
@@ -112,7 +112,9 @@ export const reporter = (
         );
         radio.emit(
           "logFailure",
-          `- Arguments: ${JSON.stringify(ce.invariantArgs)}`,
+          `- Arguments: ${(ce.invariantArgs as ClarityValue[])
+            .map((cv) => cvToString(cv))
+            .join(" ")}`,
         );
         radio.emit("logFailure", `- Caller   : ${ce.invariantCaller[0]}`);
 

--- a/heatstroke.ts
+++ b/heatstroke.ts
@@ -1,6 +1,7 @@
 import type { EventEmitter } from "node:events";
 
 import type { ContractInterfaceFunction } from "@stacks/clarinet-sdk-wasm";
+import { cvToString, type ClarityValue } from "@stacks/transactions";
 import { green } from "ansicolor";
 
 import type {
@@ -149,7 +150,9 @@ export const reporter = (
         );
         radio.emit(
           "logFailure",
-          `- Arguments     : ${JSON.stringify(ce.functionArgs)}`,
+          `- Arguments     : ${(ce.functionArgs as ClarityValue[])
+            .map((cv) => cvToString(cv))
+            .join(" ")}`,
         );
         radio.emit("logFailure", `- Caller        : ${ce.testCaller[0]}`);
         radio.emit(

--- a/invariant.ts
+++ b/invariant.ts
@@ -15,7 +15,11 @@ import fc from "fast-check";
 import { DialerRegistry, PostDialerError, PreDialerError } from "./dialer";
 import { reporter } from "./heatstroke";
 import type { Statistics } from "./heatstroke.types";
-import type { LocalContext } from "./invariant.types";
+import type {
+  InvariantTestConfig,
+  InvariantTestContext,
+  LocalContext,
+} from "./invariant.types";
 import { strategyFor } from "./lib";
 import {
   getFailureFilePath,
@@ -275,32 +279,6 @@ export const checkInvariants = async (
     });
   }
 };
-
-/**
- * The configuration for an invariant test.
- */
-interface InvariantTestConfig {
-  simnet: Simnet;
-  targetContractName: string;
-  rendezvousContractId: string;
-  runs: number | undefined;
-  seed: number | undefined;
-  bail: boolean;
-  dial: string | undefined;
-  radio: EventEmitter;
-  eligibleAccounts: Map<string, string>;
-  allAddresses: string[];
-}
-
-/**
- * The context to run an invariant test with.
- */
-interface InvariantTestContext {
-  /** SUT functions for the target contract. */
-  functions: EnrichedContractInterfaceFunction[];
-  /** Invariant functions for the target contract. */
-  invariants: EnrichedContractInterfaceFunction[];
-}
 
 /**
  * Runs an invariant test.

--- a/invariant.ts
+++ b/invariant.ts
@@ -3,7 +3,12 @@ import { resolve } from "node:path";
 
 import type { Simnet } from "@stacks/clarinet-sdk";
 import type { ContractInterfaceFunction } from "@stacks/clarinet-sdk-wasm";
-import { Cl, cvToJSON, cvToString } from "@stacks/transactions";
+import {
+  Cl,
+  cvToJSON,
+  cvToString,
+  type ClarityValue,
+} from "@stacks/transactions";
 import { dim, green, red, underline, yellow } from "ansicolor";
 import fc from "fast-check";
 
@@ -11,14 +16,13 @@ import { DialerRegistry, PostDialerError, PreDialerError } from "./dialer";
 import { reporter } from "./heatstroke";
 import type { Statistics } from "./heatstroke.types";
 import type { LocalContext } from "./invariant.types";
+import { strategyFor } from "./lib";
 import {
   getFailureFilePath,
   loadFailures,
   persistFailure,
 } from "./persistence";
 import {
-  argsToCV,
-  functionToArbitrary,
   getContractNameFromContractId,
   getFunctionsListForContract,
   LOG_DIVIDER,
@@ -31,7 +35,6 @@ import {
   getNonTestableTraitFunctions,
   isTraitReferenceFunction,
 } from "./traits";
-import type { ImplementedTraitType } from "./traits.types";
 
 /**
  * Runs invariant testing on the target contract and logs the progress. Reports
@@ -247,7 +250,6 @@ export const checkInvariants = async (
         allAddresses,
         functions,
         invariants,
-        projectTraitImplementations,
       });
     }
   } else {
@@ -270,7 +272,6 @@ export const checkInvariants = async (
       allAddresses,
       functions,
       invariants,
-      projectTraitImplementations,
     });
   }
 };
@@ -299,8 +300,6 @@ interface InvariantTestContext {
   functions: EnrichedContractInterfaceFunction[];
   /** Invariant functions for the target contract. */
   invariants: EnrichedContractInterfaceFunction[];
-  /** Project trait implementations. */
-  projectTraitImplementations: Record<string, ImplementedTraitType[]>;
 }
 
 /**
@@ -325,8 +324,19 @@ const invariantTest = async (
     allAddresses,
     functions,
     invariants,
-    projectTraitImplementations,
   } = config;
+
+  // Pre-build one fast-check arbitrary per SUT and invariant function via
+  // the public library API, so invariant runs exercise the same strategy
+  // pipeline as library consumers. `allAddresses` is threaded through so
+  // any upstream account filtering (e.g. user-restricted accounts) is
+  // honored.
+  const sutStrategies = new Map<string, fc.Arbitrary<ClarityValue[]>>(
+    functions.map((fn) => [fn.name, strategyFor(simnet, fn, allAddresses)]),
+  );
+  const invariantStrategies = new Map<string, fc.Arbitrary<ClarityValue[]>>(
+    invariants.map((fn) => [fn.name, strategyFor(simnet, fn, allAddresses)]),
+  );
 
   /**
    * The dialer registry, which is used to keep track of all the custom dialers
@@ -409,23 +419,12 @@ const invariantTest = async (
                 },
               ),
               selectedFunctionsArgsList: fc.tuple(
-                ...r.selectedFunctions.map((selectedFunction) =>
-                  fc.tuple(
-                    ...functionToArbitrary(
-                      selectedFunction,
-                      allAddresses,
-                      projectTraitImplementations,
-                    ),
-                  ),
+                ...r.selectedFunctions.map(
+                  (selectedFunction) =>
+                    sutStrategies.get(selectedFunction.name)!,
                 ),
               ),
-              invariantArgs: fc.tuple(
-                ...functionToArbitrary(
-                  r.selectedInvariant,
-                  allAddresses,
-                  projectTraitImplementations,
-                ),
-              ),
+              invariantArgs: invariantStrategies.get(r.selectedInvariant.name)!,
             })
             .map((args) => ({ ...r, ...args })),
         )
@@ -448,19 +447,10 @@ const invariantTest = async (
             .map((burnBlocks) => ({ ...r, ...burnBlocks })),
         ),
       async (r) => {
-        const selectedFunctionsArgsCV = r.selectedFunctions.map(
-          (selectedFunction, index) =>
-            argsToCV(selectedFunction, r.selectedFunctionsArgsList[index]),
-        );
-        const selectedInvariantArgsCV = argsToCV(
-          r.selectedInvariant,
-          r.invariantArgs,
-        );
-
         for (const [index, selectedFunction] of r.selectedFunctions.entries()) {
           const [sutCallerWallet, sutCallerAddress] = r.sutCallers[index];
 
-          const printedFunctionArgs = selectedFunctionsArgsCV[index]
+          const printedFunctionArgs = r.selectedFunctionsArgsList[index]
             .map((cv) => cvToString(cv))
             .join(" ");
 
@@ -469,7 +459,7 @@ const invariantTest = async (
               await dialerRegistry.executePreDialers({
                 selectedFunction: selectedFunction,
                 functionCall: undefined,
-                clarityValueArguments: selectedFunctionsArgsCV[index],
+                clarityValueArguments: r.selectedFunctionsArgsList[index],
               });
             }
           } catch (error: any) {
@@ -480,7 +470,7 @@ const invariantTest = async (
             const functionCall = simnet.callPublicFn(
               r.rendezvousContractId,
               selectedFunction.name,
-              selectedFunctionsArgsCV[index],
+              r.selectedFunctionsArgsList[index],
               sutCallerAddress,
             );
 
@@ -531,7 +521,7 @@ const invariantTest = async (
                   await dialerRegistry.executePostDialers({
                     selectedFunction: selectedFunction,
                     functionCall: functionCall,
-                    clarityValueArguments: selectedFunctionsArgsCV[index],
+                    clarityValueArguments: r.selectedFunctionsArgsList[index],
                   });
                 }
               } catch (error: any) {
@@ -588,7 +578,7 @@ const invariantTest = async (
           }
         }
 
-        const printedInvariantArgs = selectedInvariantArgsCV
+        const printedInvariantArgs = r.invariantArgs
           .map((cv) => cvToString(cv))
           .join(" ");
 
@@ -599,7 +589,7 @@ const invariantTest = async (
           const { result: invariantCallResult } = simnet.callReadOnlyFn(
             r.rendezvousContractId,
             r.selectedInvariant.name,
-            selectedInvariantArgsCV,
+            r.invariantArgs,
             invariantCallerAddress,
           );
 

--- a/invariant.ts
+++ b/invariant.ts
@@ -460,16 +460,8 @@ const invariantTest = async (
         for (const [index, selectedFunction] of r.selectedFunctions.entries()) {
           const [sutCallerWallet, sutCallerAddress] = r.sutCallers[index];
 
-          const printedFunctionArgs = r.selectedFunctionsArgsList[index]
-            .map((arg) => {
-              try {
-                return typeof arg === "object"
-                  ? JSON.stringify(arg)
-                  : (arg as any).toString();
-              } catch {
-                return "[Circular]";
-              }
-            })
+          const printedFunctionArgs = selectedFunctionsArgsCV[index]
+            .map((cv) => cvToString(cv))
             .join(" ");
 
           try {
@@ -596,16 +588,8 @@ const invariantTest = async (
           }
         }
 
-        const printedInvariantArgs = r.invariantArgs
-          .map((arg) => {
-            try {
-              return typeof arg === "object"
-                ? JSON.stringify(arg)
-                : arg.toString();
-            } catch {
-              return "[Circular]";
-            }
-          })
+        const printedInvariantArgs = selectedInvariantArgsCV
+          .map((cv) => cvToString(cv))
           .join(" ");
 
         const [invariantCallerWallet, invariantCallerAddress] =

--- a/invariant.types.ts
+++ b/invariant.types.ts
@@ -1,3 +1,9 @@
+import type { EventEmitter } from "node:events";
+
+import type { Simnet } from "@stacks/clarinet-sdk";
+
+import type { EnrichedContractInterfaceFunction } from "./shared.types";
+
 type ContractId = string;
 
 type SutFunctionName = string;
@@ -10,3 +16,29 @@ type SutFunctionName = string;
  * - The value is the count of times the SUT function has been invoked.
  */
 export type LocalContext = Record<ContractId, Record<SutFunctionName, number>>;
+
+/**
+ * The configuration for an invariant test.
+ */
+export interface InvariantTestConfig {
+  simnet: Simnet;
+  targetContractName: string;
+  rendezvousContractId: string;
+  runs: number | undefined;
+  seed: number | undefined;
+  bail: boolean;
+  dial: string | undefined;
+  radio: EventEmitter;
+  eligibleAccounts: Map<string, string>;
+  allAddresses: string[];
+}
+
+/**
+ * The context to run an invariant test with.
+ */
+export interface InvariantTestContext {
+  /** SUT functions for the target contract. */
+  functions: EnrichedContractInterfaceFunction[];
+  /** Invariant functions for the target contract. */
+  invariants: EnrichedContractInterfaceFunction[];
+}

--- a/lib.tests.ts
+++ b/lib.tests.ts
@@ -105,4 +105,21 @@ describe("strategyFor", () => {
       { numRuns: 5 },
     );
   });
+
+  it("honors allAddresses override for principal-typed arguments", async () => {
+    const simnet = await initSimnet(manifestPath);
+    const fn = getContractFunction(simnet, "rendezvous-token", "mint");
+    const restrictedAddress = [...simnet.getAccounts().values()][0];
+    const arb = strategyFor(simnet, fn, [restrictedAddress]);
+
+    fc.assert(
+      fc.property(arb, (args: ClarityValue[]) => {
+        const [recipientArg] = args;
+        expect(recipientArg).toEqual(
+          expect.objectContaining({ value: restrictedAddress }),
+        );
+      }),
+      { numRuns: 10 },
+    );
+  });
 });

--- a/lib.tests.ts
+++ b/lib.tests.ts
@@ -1,0 +1,108 @@
+import { join, resolve } from "node:path";
+
+import { initSimnet } from "@stacks/clarinet-sdk";
+import type { ClarityValue } from "@stacks/transactions";
+import fc from "fast-check";
+
+import { getContractFunction, strategyFor } from "./lib";
+
+const manifestPath = join(resolve(__dirname, "example"), "Clarinet.toml");
+
+describe("getContractFunction", () => {
+  it("returns the function interface for a known contract and function", async () => {
+    const simnet = await initSimnet(manifestPath);
+    const fn = getContractFunction(simnet, "counter", "increment");
+
+    expect(fn.name).toBe("increment");
+    expect(fn.access).toBe("public");
+  });
+
+  it("returns a function with arguments", async () => {
+    const simnet = await initSimnet(manifestPath);
+    const fn = getContractFunction(simnet, "counter", "add");
+
+    expect(fn.name).toBe("add");
+    expect(fn.args.length).toBe(1);
+  });
+
+  it("throws when the contract does not exist", async () => {
+    const simnet = await initSimnet(manifestPath);
+
+    expect(() => getContractFunction(simnet, "nonexistent", "foo")).toThrow(
+      'Contract "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.nonexistent" not found.',
+    );
+  });
+
+  it("throws when the function does not exist", async () => {
+    const simnet = await initSimnet(manifestPath);
+
+    expect(() => getContractFunction(simnet, "counter", "nonexistent")).toThrow(
+      'Function "nonexistent" not found in contract "counter".',
+    );
+  });
+
+  it("accepts a custom deployer address", async () => {
+    const simnet = await initSimnet(manifestPath);
+
+    // Using the actual deployer explicitly should work the same.
+    const fn = getContractFunction(
+      simnet,
+      "counter",
+      "increment",
+      simnet.deployer,
+    );
+    expect(fn.name).toBe("increment");
+  });
+});
+
+describe("strategyFor", () => {
+  it("produces ClarityValue arrays for a function with arguments", async () => {
+    const simnet = await initSimnet(manifestPath);
+    const fn = getContractFunction(simnet, "counter", "add");
+    const arb = strategyFor(fn, simnet);
+
+    fc.assert(
+      fc.property(arb, (args: ClarityValue[]) => {
+        expect(Array.isArray(args)).toBe(true);
+        expect(args.length).toBe(fn.args.length);
+        args.forEach((arg) => {
+          expect(arg).toHaveProperty("type");
+        });
+      }),
+      { numRuns: 10 },
+    );
+  });
+
+  it("produces an empty array for a function with no arguments", async () => {
+    const simnet = await initSimnet(manifestPath);
+    const fn = getContractFunction(simnet, "counter", "increment");
+    const arb = strategyFor(fn, simnet);
+
+    fc.assert(
+      fc.property(arb, (args: ClarityValue[]) => {
+        expect(args).toEqual([]);
+      }),
+      { numRuns: 1 },
+    );
+  });
+
+  it("produces arguments usable with simnet.callPublicFn", async () => {
+    const simnet = await initSimnet(manifestPath);
+    const fn = getContractFunction(simnet, "counter", "add");
+    const arb = strategyFor(fn, simnet);
+
+    fc.assert(
+      fc.property(arb, (args: ClarityValue[]) => {
+        // Should not throw — arguments are valid Clarity values.
+        const { result } = simnet.callPublicFn(
+          `${simnet.deployer}.counter`,
+          "add",
+          args,
+          simnet.deployer,
+        );
+        expect(result).toBeDefined();
+      }),
+      { numRuns: 5 },
+    );
+  });
+});

--- a/lib.tests.ts
+++ b/lib.tests.ts
@@ -59,7 +59,7 @@ describe("strategyFor", () => {
   it("produces ClarityValue arrays for a function with arguments", async () => {
     const simnet = await initSimnet(manifestPath);
     const fn = getContractFunction(simnet, "counter", "add");
-    const arb = strategyFor(fn, simnet);
+    const arb = strategyFor(simnet, fn);
 
     fc.assert(
       fc.property(arb, (args: ClarityValue[]) => {
@@ -76,7 +76,7 @@ describe("strategyFor", () => {
   it("produces an empty array for a function with no arguments", async () => {
     const simnet = await initSimnet(manifestPath);
     const fn = getContractFunction(simnet, "counter", "increment");
-    const arb = strategyFor(fn, simnet);
+    const arb = strategyFor(simnet, fn);
 
     fc.assert(
       fc.property(arb, (args: ClarityValue[]) => {
@@ -89,7 +89,7 @@ describe("strategyFor", () => {
   it("produces arguments usable with simnet.callPublicFn", async () => {
     const simnet = await initSimnet(manifestPath);
     const fn = getContractFunction(simnet, "counter", "add");
-    const arb = strategyFor(fn, simnet);
+    const arb = strategyFor(simnet, fn);
 
     fc.assert(
       fc.property(arb, (args: ClarityValue[]) => {

--- a/lib.ts
+++ b/lib.ts
@@ -1,0 +1,127 @@
+import type { Simnet } from "@stacks/clarinet-sdk";
+import type { ContractInterfaceFunction } from "@stacks/clarinet-sdk-wasm";
+import type { ClarityValue } from "@stacks/transactions";
+import fc from "fast-check";
+
+import { argsToCV, functionToArbitrary } from "./shared";
+import type { EnrichedContractInterfaceFunction } from "./shared.types";
+import {
+  buildTraitReferenceMap,
+  enrichInterfaceWithTraitData,
+  extractProjectTraitImplementations,
+  isTraitReferenceFunction,
+} from "./traits";
+
+export type { EnrichedContractInterfaceFunction } from "./shared.types";
+
+/**
+ * Retrieves a function interface from a simnet contract by name. The returned
+ * interface is enriched with trait reference data when applicable, making it
+ * ready for use with {@link strategyFor}.
+ *
+ * @param simnet The simnet instance.
+ * @param contractName The contract name (e.g., "counter").
+ * @param functionName The function name (e.g., "increment").
+ * @param deployer The deployer address. Defaults to `simnet.deployer`.
+ * @returns The enriched function interface.
+ *
+ * @example
+ * ```ts
+ * const simnet = await initSimnet("./Clarinet.toml");
+ * const increment = getContractFunction(simnet, "counter", "increment");
+ * ```
+ */
+export const getContractFunction = (
+  simnet: Simnet,
+  contractName: string,
+  functionName: string,
+  deployer?: string,
+): EnrichedContractInterfaceFunction => {
+  const targetDeployer = deployer ?? simnet.deployer;
+  const allContracts = simnet.getContractsInterfaces();
+
+  const contractId = `${targetDeployer}.${contractName}`;
+  const contractInterface = allContracts.get(contractId);
+
+  if (!contractInterface) {
+    throw new Error(`Contract "${contractId}" not found.`);
+  }
+
+  const fn = contractInterface.functions.find(
+    (f: ContractInterfaceFunction) => f.name === functionName,
+  );
+
+  if (!fn) {
+    throw new Error(
+      `Function "${functionName}" not found in contract "${contractName}".`,
+    );
+  }
+
+  // Enrich with trait data if the function uses trait references.
+  if (isTraitReferenceFunction(fn)) {
+    const traitReferenceMap = buildTraitReferenceMap([fn]);
+    const enriched = enrichInterfaceWithTraitData(
+      simnet.getContractAST(contractName),
+      traitReferenceMap,
+      [fn],
+      contractId,
+    );
+    return enriched.get(contractId)![0];
+  }
+
+  return fn as EnrichedContractInterfaceFunction;
+};
+
+/**
+ * Generates a fast-check arbitrary that produces `ClarityValue[]` arrays
+ * ready for use with `simnet.callPublicFn` or similar.
+ *
+ * Automatically resolves principal addresses and trait implementations from
+ * the simnet instance.
+ *
+ * @param fn The enriched function interface (from {@link getContractFunction}).
+ * @param simnet The simnet instance.
+ * @returns A fast-check arbitrary producing Clarity argument arrays.
+ *
+ * @example
+ * ```ts
+ * import fc from "fast-check";
+ * import { initSimnet } from "@stacks/clarinet-sdk";
+ * import { getContractFunction, strategyFor } from "@stacks/rendezvous";
+ *
+ * const simnet = await initSimnet("./Clarinet.toml");
+ * const increment = getContractFunction(simnet, "counter", "increment");
+ * const argsArb = strategyFor(increment, simnet);
+ *
+ * fc.assert(
+ *   fc.asyncProperty(argsArb, async (args) => {
+ *     const { result } = simnet.callPublicFn(
+ *       "deployer.counter", "increment", args, "deployer"
+ *     );
+ *     return result.type !== "err";
+ *   })
+ * );
+ * ```
+ */
+export const strategyFor = (
+  fn: EnrichedContractInterfaceFunction,
+  simnet: Simnet,
+): fc.Arbitrary<ClarityValue[]> => {
+  const allAddresses = [...simnet.getAccounts().values()];
+  const projectTraitImplementations =
+    extractProjectTraitImplementations(simnet);
+
+  const arbitraries = functionToArbitrary(
+    fn,
+    allAddresses,
+    projectTraitImplementations,
+  );
+
+  if (arbitraries.length === 0) {
+    return fc.constant([]);
+  }
+
+  return fc
+    .tuple(...arbitraries)
+    .map((generated: unknown[]) => argsToCV(fn, generated));
+};

--- a/lib.ts
+++ b/lib.ts
@@ -104,7 +104,10 @@ export const getContractFunction = (
  * fc.assert(
  *   fc.property(argsArb, (args) => {
  *     const { result } = simnet.callPublicFn(
- *       "deployer.counter", "increment", args, "deployer"
+ *       "counter",
+ *       "increment",
+ *       args,
+ *       simnet.deployer,
  *     );
  *     return result.type !== "err";
  *   })

--- a/lib.ts
+++ b/lib.ts
@@ -11,6 +11,7 @@ import {
   extractProjectTraitImplementations,
   isTraitReferenceFunction,
 } from "./traits";
+import type { ImplementedTraitType } from "./traits.types";
 
 export type { EnrichedContractInterfaceFunction } from "./shared.types";
 
@@ -76,11 +77,18 @@ export const getContractFunction = (
  * Generates a fast-check arbitrary that produces `ClarityValue[]` arrays
  * ready for use with `simnet.callPublicFn` or similar.
  *
- * Automatically resolves principal addresses and trait implementations from
- * the simnet instance.
+ * By default, principal addresses and trait implementations are resolved from
+ * the simnet instance. Pass `allAddresses` to restrict the principal pool
+ * (e.g. to a user-filtered account set), and `projectTraitImplementations` to
+ * reuse a precomputed map.
  *
  * @param simnet The simnet instance.
  * @param fn The enriched function interface (from {@link getContractFunction}).
+ * @param allAddresses Optional addresses used for principal-typed argument
+ *   generation. Defaults to all accounts in the simnet.
+ * @param projectTraitImplementations Optional project/requirement contracts
+ *   keyed by the traits they implement. Defaults to extracting them from the
+ *   simnet.
  * @returns A fast-check arbitrary producing Clarity argument arrays.
  *
  * @example
@@ -106,15 +114,18 @@ export const getContractFunction = (
 export const strategyFor = (
   simnet: Simnet,
   fn: EnrichedContractInterfaceFunction,
+  allAddresses?: string[],
+  projectTraitImplementations?: Record<string, ImplementedTraitType[]>,
 ): fc.Arbitrary<ClarityValue[]> => {
-  const allAddresses = [...simnet.getAccounts().values()];
-  const projectTraitImplementations =
-    extractProjectTraitImplementations(simnet);
+  const resolvedAddresses =
+    allAddresses ?? [...simnet.getAccounts().values()];
+  const resolvedTraitImplementations =
+    projectTraitImplementations ?? extractProjectTraitImplementations(simnet);
 
   const arbitraries = functionToArbitrary(
     fn,
-    allAddresses,
-    projectTraitImplementations,
+    resolvedAddresses,
+    resolvedTraitImplementations,
   );
 
   if (arbitraries.length === 0) {

--- a/lib.ts
+++ b/lib.ts
@@ -117,8 +117,7 @@ export const strategyFor = (
   allAddresses?: string[],
   projectTraitImplementations?: Record<string, ImplementedTraitType[]>,
 ): fc.Arbitrary<ClarityValue[]> => {
-  const resolvedAddresses =
-    allAddresses ?? [...simnet.getAccounts().values()];
+  const resolvedAddresses = allAddresses ?? [...simnet.getAccounts().values()];
   const resolvedTraitImplementations =
     projectTraitImplementations ?? extractProjectTraitImplementations(simnet);
 

--- a/lib.ts
+++ b/lib.ts
@@ -79,8 +79,8 @@ export const getContractFunction = (
  * Automatically resolves principal addresses and trait implementations from
  * the simnet instance.
  *
- * @param fn The enriched function interface (from {@link getContractFunction}).
  * @param simnet The simnet instance.
+ * @param fn The enriched function interface (from {@link getContractFunction}).
  * @returns A fast-check arbitrary producing Clarity argument arrays.
  *
  * @example
@@ -91,10 +91,10 @@ export const getContractFunction = (
  *
  * const simnet = await initSimnet("./Clarinet.toml");
  * const increment = getContractFunction(simnet, "counter", "increment");
- * const argsArb = strategyFor(increment, simnet);
+ * const argsArb = strategyFor(simnet, increment);
  *
  * fc.assert(
- *   fc.asyncProperty(argsArb, async (args) => {
+ *   fc.property(argsArb, (args) => {
  *     const { result } = simnet.callPublicFn(
  *       "deployer.counter", "increment", args, "deployer"
  *     );
@@ -104,8 +104,8 @@ export const getContractFunction = (
  * ```
  */
 export const strategyFor = (
-  fn: EnrichedContractInterfaceFunction,
   simnet: Simnet,
+  fn: EnrichedContractInterfaceFunction,
 ): fc.Arbitrary<ClarityValue[]> => {
   const allAddresses = [...simnet.getAccounts().values()];
   const projectTraitImplementations =

--- a/package.json
+++ b/package.json
@@ -2,9 +2,16 @@
   "name": "@stacks/rendezvous",
   "version": "0.14.0",
   "description": "Meet your contract's vulnerabilities head-on.",
-  "main": "app.js",
+  "main": "dist/lib.js",
+  "types": "dist/lib.d.ts",
   "bin": {
     "rv": "./dist/app.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/lib.d.ts",
+      "default": "./dist/lib.js"
+    }
   },
   "scripts": {
     "build": "npx -p typescript tsc --project tsconfig.json && node -e \"if (process.platform !== 'win32') require('fs').chmodSync('./dist/app.js', 0o755);\"",

--- a/property.ts
+++ b/property.ts
@@ -407,16 +407,8 @@ const propertyTest = async (
           r.functionArgs,
         );
 
-        const printedTestFunctionArgs = r.functionArgs
-          .map((arg) => {
-            try {
-              return typeof arg === "object"
-                ? JSON.stringify(arg)
-                : arg.toString();
-            } catch {
-              return "[Circular]";
-            }
-          })
+        const printedTestFunctionArgs = selectedTestFunctionArgs
+          .map((cv) => cvToString(cv))
           .join(" ");
 
         const [testCallerWallet, testCallerAddress] = r.testCaller;

--- a/property.ts
+++ b/property.ts
@@ -3,20 +3,19 @@ import { resolve } from "node:path";
 
 import type { Simnet } from "@stacks/clarinet-sdk";
 import type { ContractInterfaceFunction } from "@stacks/clarinet-sdk-wasm";
-import { cvToJSON, cvToString } from "@stacks/transactions";
+import { cvToJSON, cvToString, type ClarityValue } from "@stacks/transactions";
 import { dim, green, red, underline, yellow } from "ansicolor";
 import fc from "fast-check";
 
 import { reporter } from "./heatstroke";
 import type { Statistics } from "./heatstroke.types";
+import { strategyFor } from "./lib";
 import {
   getFailureFilePath,
   loadFailures,
   persistFailure,
 } from "./persistence";
 import {
-  argsToCV,
-  functionToArbitrary,
   getContractNameFromContractId,
   getFunctionsListForContract,
   LOG_DIVIDER,
@@ -29,7 +28,6 @@ import {
   getNonTestableTraitFunctions,
   isTraitReferenceFunction,
 } from "./traits";
-import type { ImplementedTraitType } from "./traits.types";
 
 /**
  * Runs property-based tests on the target contract and logs the progress.
@@ -244,7 +242,6 @@ export const checkProperties = async (
         eligibleAccounts,
         allAddresses,
         testFunctions,
-        projectTraitImplementations,
         testContractsPairedFunctions,
       });
     }
@@ -266,7 +263,6 @@ export const checkProperties = async (
       eligibleAccounts,
       allAddresses,
       testFunctions,
-      projectTraitImplementations,
       testContractsPairedFunctions,
     });
   }
@@ -293,8 +289,6 @@ interface PropertyTestConfig {
 interface PropertyTestContext {
   /** Executable test functions. */
   testFunctions: EnrichedContractInterfaceFunction[];
-  /** Project trait implementations. */
-  projectTraitImplementations: Record<string, ImplementedTraitType[]>;
   /** Test functions paired with their corresponding discard functions. */
   testContractsPairedFunctions: Map<string, Map<string, string | undefined>>;
 }
@@ -319,9 +313,16 @@ const propertyTest = async (
     eligibleAccounts,
     allAddresses,
     testFunctions,
-    projectTraitImplementations,
     testContractsPairedFunctions,
   } = config;
+
+  // Pre-build one fast-check arbitrary per test function via the public
+  // library API, so property runs exercise the same strategy pipeline as
+  // library consumers. `allAddresses` is threaded through so any upstream
+  // account filtering (e.g. user-restricted accounts) is honored.
+  const strategies = new Map<string, fc.Arbitrary<ClarityValue[]>>(
+    testFunctions.map((fn) => [fn.name, strategyFor(simnet, fn, allAddresses)]),
+  );
 
   const statistics: Statistics = {
     test: {
@@ -373,13 +374,7 @@ const propertyTest = async (
         .chain((r) =>
           fc
             .record({
-              functionArgs: fc.tuple(
-                ...functionToArbitrary(
-                  r.selectedTestFunction,
-                  allAddresses,
-                  projectTraitImplementations,
-                ),
-              ),
+              functionArgs: strategies.get(r.selectedTestFunction.name)!,
             })
             .map((args) => ({ ...r, ...args })),
         )
@@ -402,12 +397,7 @@ const propertyTest = async (
             .map((burnBlocks) => ({ ...r, ...burnBlocks })),
         ),
       async (r) => {
-        const selectedTestFunctionArgs = argsToCV(
-          r.selectedTestFunction,
-          r.functionArgs,
-        );
-
-        const printedTestFunctionArgs = selectedTestFunctionArgs
+        const printedTestFunctionArgs = r.functionArgs
           .map((cv) => cvToString(cv))
           .join(" ");
 
@@ -419,7 +409,7 @@ const propertyTest = async (
 
         const discarded = isTestDiscarded(
           discardFunctionName,
-          selectedTestFunctionArgs,
+          r.functionArgs,
           r.rendezvousContractId,
           simnet,
           testCallerAddress,
@@ -447,7 +437,7 @@ const propertyTest = async (
             const { result: testFunctionCallResult } = simnet.callPublicFn(
               r.rendezvousContractId,
               r.selectedTestFunction.name,
-              selectedTestFunctionArgs,
+              r.functionArgs,
               testCallerAddress,
             );
 

--- a/property.ts
+++ b/property.ts
@@ -15,12 +15,12 @@ import {
   loadFailures,
   persistFailure,
 } from "./persistence";
+import type { PropertyTestConfig, PropertyTestContext } from "./property.types";
 import {
   getContractNameFromContractId,
   getFunctionsListForContract,
   LOG_DIVIDER,
 } from "./shared";
-import type { EnrichedContractInterfaceFunction } from "./shared.types";
 import {
   buildTraitReferenceMap,
   enrichInterfaceWithTraitData,
@@ -267,31 +267,6 @@ export const checkProperties = async (
     });
   }
 };
-
-/**
- * The configuration for a property test.
- */
-interface PropertyTestConfig {
-  simnet: Simnet;
-  targetContractName: string;
-  rendezvousContractId: string;
-  runs: number | undefined;
-  seed: number | undefined;
-  bail: boolean;
-  radio: EventEmitter;
-  eligibleAccounts: Map<string, string>;
-  allAddresses: string[];
-}
-
-/**
- * The context to run a property test with.
- */
-interface PropertyTestContext {
-  /** Executable test functions. */
-  testFunctions: EnrichedContractInterfaceFunction[];
-  /** Test functions paired with their corresponding discard functions. */
-  testContractsPairedFunctions: Map<string, Map<string, string | undefined>>;
-}
 
 /**
  * Runs a property test.

--- a/property.types.ts
+++ b/property.types.ts
@@ -1,2 +1,30 @@
-// This file is a placeholder for the property-based testing routine-related
-// types.
+import type { EventEmitter } from "node:events";
+
+import type { Simnet } from "@stacks/clarinet-sdk";
+
+import type { EnrichedContractInterfaceFunction } from "./shared.types";
+
+/**
+ * The configuration for a property test.
+ */
+export interface PropertyTestConfig {
+  simnet: Simnet;
+  targetContractName: string;
+  rendezvousContractId: string;
+  runs: number | undefined;
+  seed: number | undefined;
+  bail: boolean;
+  radio: EventEmitter;
+  eligibleAccounts: Map<string, string>;
+  allAddresses: string[];
+}
+
+/**
+ * The context to run a property test with.
+ */
+export interface PropertyTestContext {
+  /** Executable test functions. */
+  testFunctions: EnrichedContractInterfaceFunction[];
+  /** Test functions paired with their corresponding discard functions. */
+  testContractsPairedFunctions: Map<string, Map<string, string | undefined>>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,8 +49,8 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declarationMap": true,                              /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */


### PR DESCRIPTION
Clarity smart contracts benefit from property-based testing, but setting up `fast-check` arbitraries that produce valid Clarity values for every parameter type (uint, principal, buffers, lists, tuples, optionals, responses, trait references) is tedious and error-prone. Rendezvous already solves this internally; this PR exposes that capability as a library API so the community can use it off-the-shelf.                                                                                                                                            

Two new exports:
- `getContractFunction(simnet, contract, fn, deployer?)`: extracts a function interface from a deployed contract, enriched with trait data                                                                                                                                
- `generateArgs(simnet, fn)`: returns `fc.Arbitrary<ClarityValue[]>`, handling all Clarity types including recursive structures (list of tuples, optional of response, etc.) and trait reference resolution                                                                                                                                           

The package now works as both a CLI (`npx rv`) and a library (`import { generateArgs } from "@stacks/rendezvous"`). TypeScript declarations are included.

Fixes #168.