### PR TITLE
Bump version to 1.0.0-rc.1

### DIFF
--- a/.github/workflows/npm-publish-release.yml
+++ b/.github/workflows/npm-publish-release.yml
@@ -23,10 +23,21 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run build
-      - run: npm publish
+      - name: Publish
+        run: |
+          # Keep RCs off the `latest` dist-tag so plain `npm install` still
+          # resolves to the latest stable release.
+          if [[ "${GITHUB_REF_NAME}" == *-rc* ]]; then
+            npm publish --tag rc
+          else
+            npm publish
+          fi
 
   update-example-post-release:
     needs: publish
+    # Skip for RCs so master's example project stays pinned to a stable
+    # release.
+    if: ${{ !contains(github.ref_name, '-rc') }}
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ github.ref_name }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stacks/rendezvous",
-  "version": "0.14.0",
+  "version": "1.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stacks/rendezvous",
-      "version": "0.14.0",
+      "version": "1.0.0-rc.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@stacks/clarinet-sdk": "^3.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.14.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@stacks/clarinet-sdk": "^3.15.0",
+        "@stacks/clarinet-sdk": "^3.16.0",
         "@stacks/transactions": "^7.3.1",
         "ansicolor": "^2.0.3",
         "fast-check": "^4.5.3"
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
-        "@stacks/clarinet-sdk-wasm": "^3.15.0",
+        "@stacks/clarinet-sdk-wasm": "^3.16.0",
         "@types/jest": "^30.0.0",
         "jest": "^30.2.0",
         "oxlint": "^1.58.0",
@@ -1452,25 +1452,32 @@
       }
     },
     "node_modules/@stacks/clarinet-sdk": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.15.0.tgz",
-      "integrity": "sha512-UgutsThF4/xb9WGD88X6t2VZ5yhot+XMe1BFw9s6fESnI6HmK4AwKpJLX5lzShmMdhpZkWs4GUMwMefRXEzjKg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.16.0.tgz",
+      "integrity": "sha512-IhKXuEQnq8vfh97f3R05IHJlUqzT6kOcyWAihOgpb+Ap7t/OA2aCQQfsz4qXonnFXxA1uzojihFAMigMZ/VfNA==",
       "license": "GPL-3.0",
       "dependencies": {
-        "@stacks/clarinet-sdk-wasm": "3.15.0",
-        "@stacks/transactions": "^7.0.6",
-        "kolorist": "^1.8.0",
-        "prompts": "^2.4.2",
-        "yargs": "^18.0.0"
+        "@stacks/clarinet-sdk-wasm": "15.16.0",
+        "@stacks/transactions": "7.4.0",
+        "kolorist": "1.8.0",
+        "prompts": "2.4.2",
+        "yargs": "18.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@stacks/clarinet-sdk-wasm": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.15.0.tgz",
-      "integrity": "sha512-gGVgBbUmWC3Eyw7eI6dn8s2sIPIOpeDWXo7pTfAuSvCO/ov/2vE0CgGjkjRlo1NjVY3193GlN397BySuhVoViA==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.16.0.tgz",
+      "integrity": "sha512-nDyE8DJPuv4OgIcOh94l0YtJ433v7EsuFPfJ3vI1qb98orsXrlEWmjPtXzZzpUtUvM/SPD3PYGUMcffhB/jlfw==",
+      "dev": true,
+      "license": "GPL-3.0"
+    },
+    "node_modules/@stacks/clarinet-sdk/node_modules/@stacks/clarinet-sdk-wasm": {
+      "version": "15.16.0",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-15.16.0.tgz",
+      "integrity": "sha512-OBffQar1BSw0EZ9vnXeSLuVw4O0qfiFgcsSWcDvjybWOew41lUmSLa0QDwbfnKW0tmw2WAC6fDzzHZGQnhHWgg==",
       "license": "GPL-3.0"
     },
     "node_modules/@stacks/clarinet-sdk/node_modules/ansi-styles": {
@@ -1582,9 +1589,9 @@
       }
     },
     "node_modules/@stacks/transactions": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.3.1.tgz",
-      "integrity": "sha512-ufnC1BPrOKz5b5gxxdseP3vBrFq1+qx1L6t+J/QnjXULyWdkhtS+LBEqRw2bL5qNteMvU2GhqPgFtYQPzolGbw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.4.0.tgz",
+      "integrity": "sha512-scsQO3rSNNKcPHp56Wy5OeZiIpQNmmZOORz8bkQKWjzvzycAodtSWmAoHiMFAKSleR1NyeRIz642fReqlZU9tw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/rendezvous",
-  "version": "0.14.0",
+  "version": "1.0.0-rc.1",
   "description": "Meet your contract's vulnerabilities head-on.",
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",

--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
     "url": "https://github.com/stacks-network/rendezvous.git"
   },
   "dependencies": {
-    "@stacks/clarinet-sdk": "^3.15.0",
+    "@stacks/clarinet-sdk": "^3.16.0",
     "@stacks/transactions": "^7.3.1",
     "ansicolor": "^2.0.3",
     "fast-check": "^4.5.3"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
-    "@stacks/clarinet-sdk-wasm": "^3.15.0",
+    "@stacks/clarinet-sdk-wasm": "^3.16.0",
     "@types/jest": "^30.0.0",
     "jest": "^30.2.0",
     "oxlint": "^1.58.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -105,5 +105,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["*.tests.*", "example"]
+  "exclude": ["*.tests.*", "dist", "example"]
 }


### PR DESCRIPTION
This PR updates the `npm-publish-release` workflow to suit RC tagged releases, updates to latest `@stacks/clarinet-sdk` and bumps the version to `1.0.0-rc.1`.