### PR TITLE
Fix npmjs package visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",
   "bin": {
-    "rv": "./dist/app.js"
+    "rv": "dist/app.js"
   },
   "exports": {
     ".": {
@@ -38,7 +38,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/stacks-network/rendezvous.git"
+    "url": "git+https://github.com/stacks-network/rendezvous.git"
   },
   "dependencies": {
     "@stacks/clarinet-sdk": "^3.16.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "type": "git",
     "url": "git+https://github.com/stacks-network/rendezvous.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@stacks/clarinet-sdk": "^3.16.0",
     "@stacks/transactions": "^7.3.1",


### PR DESCRIPTION
Ran `npm pkg fix` and added public access `publishConfig` to `package.json`. Related to https://github.com/stacks-network/rendezvous/actions/runs/24785362356.