### PR TITLE
Fix conditional simnet annotations in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npx rv <path-to-clarinet-project> <contract-name> <type>
 Here's an example of a test that checks reversing a list twice returns the original:
 
 ```clarity
-;;[#env(simnet)]
+;; #[env(simnet)]
 (define-public (test-reverse-list (seq (list 127 uint)))
   (begin
     (asserts!
@@ -92,7 +92,7 @@ rv example reverse test
 Here's a Clarity invariant to detect a bug in the example counter contract:
 
 ```clarity
-;;[#env(simnet)]
+;; #[env(simnet)]
 (define-read-only (invariant-counter-gt-zero)
   (let
       ((increment-num-calls (default-to u0 (get called (map-get? context "increment"))))


### PR DESCRIPTION
This PR fixes wrong Simnet code annotations present in `README`.