### PR TITLE
Add trophy case and submit first vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ fc.assert(
 
 ---
 
+### Trophy Case
+
+Real bugs and security vulnerabilities uncovered with `rv`. To add a finding, open a pull request appending a row to the table below.
+
+| Date | Project | Vulnerability | Invariant/Property | Version | Submitter |
+| ---- | ------- | ------------- | ------------------ | ------- | --------- |
+
+---
+
 ### Documentation
 
 For full documentation, see the official [Rendezvous Book](https://stacks-network.github.io/rendezvous/).

--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ fc.assert(
 
 Real bugs and security vulnerabilities uncovered with `rv`. To add a finding, open a pull request appending a row to the table below.
 
-| Date | Project | Vulnerability | Invariant/Property | Version | Submitter |
-| ---- | ------- | ------------- | ------------------ | ------- | --------- |
+| Date        | Project                                                   | Vulnerability                                                                                                             | Invariant/Property                                                                                                                                                                           | Version      | Submitter                                  |
+| ----------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ------------------------------------------ |
+| May 8, 2026 | [Jing v3](https://github.com/Rapha-btc/jing-contracts-v3) | Cancel-cycle overwrote next-cycle totals rolled forward by the small-share deposit filter, silently wiping the accounting | [`invariant-balance-eq-cycle-totals`](https://github.com/Rapha-btc/jing-contracts-v3/blob/4ff5170ac912b6948f34e5ad4ab3603ee28e1f35/tests/rv/markets-sbtc-stx-jing.invariants.clar#L226-L237) | `1.0.0-rc.1` | [@Rapha-btc](https://github.com/Rapha-btc) |
 
 ---
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,3 +28,4 @@
 ---
 
 - [Contributing](CONTRIBUTING.md)
+- [Trophy Case](https://github.com/stacks-network/rendezvous#trophy-case)


### PR DESCRIPTION
This PR adds a trophy case to `README`, links docs to it in `SUMMARY`, and records the first vulnerability reported via DM.

Congrats to @Rapha-btc!