### PR TITLE
Update main dependencies to latest versions

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,4 +28,3 @@
 ---
 
 - [Contributing](CONTRIBUTING.md)
-- [Trophy Case](https://github.com/stacks-network/rendezvous#trophy-case)

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@stacks/clarinet-sdk": "^3.15.0",
+        "@stacks/clarinet-sdk": "^3.18.1",
         "@stacks/rendezvous": "^0.14.0",
-        "@stacks/transactions": "^7.2.0",
+        "@stacks/transactions": "^7.4.0",
         "@types/node": "^24.10.0",
         "chokidar-cli": "^3.0.0",
         "vitest": "^4.0.8",
@@ -820,25 +820,25 @@
       ]
     },
     "node_modules/@stacks/clarinet-sdk": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.15.0.tgz",
-      "integrity": "sha512-UgutsThF4/xb9WGD88X6t2VZ5yhot+XMe1BFw9s6fESnI6HmK4AwKpJLX5lzShmMdhpZkWs4GUMwMefRXEzjKg==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.18.1.tgz",
+      "integrity": "sha512-qrtPK9rAFib1gJ5sz7XQeQe2CuMEuJrsYknK/nFPmoEjw8H8jOJ5UTYGeLKb+wag+kDCb5xKm38tgT6guxsBMg==",
       "license": "GPL-3.0",
       "dependencies": {
-        "@stacks/clarinet-sdk-wasm": "3.15.0",
-        "@stacks/transactions": "^7.0.6",
-        "kolorist": "^1.8.0",
-        "prompts": "^2.4.2",
-        "yargs": "^18.0.0"
+        "@stacks/clarinet-sdk-wasm": "3.18.1",
+        "@stacks/transactions": "7.4.0",
+        "kolorist": "1.8.0",
+        "prompts": "2.4.2",
+        "yargs": "18.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@stacks/clarinet-sdk-wasm": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.15.0.tgz",
-      "integrity": "sha512-gGVgBbUmWC3Eyw7eI6dn8s2sIPIOpeDWXo7pTfAuSvCO/ov/2vE0CgGjkjRlo1NjVY3193GlN397BySuhVoViA==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.18.1.tgz",
+      "integrity": "sha512-yOOIrvtIL2LKmoWqxR11Y7G7AseOnb5v1eA2kfxtf4UW0mEGAqI2esYoZLi4hXZ7LwhUsHdXPVpTjlWKitD+gA==",
       "license": "GPL-3.0"
     },
     "node_modules/@stacks/common": {
@@ -875,9 +875,9 @@
       }
     },
     "node_modules/@stacks/transactions": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.3.1.tgz",
-      "integrity": "sha512-ufnC1BPrOKz5b5gxxdseP3vBrFq1+qx1L6t+J/QnjXULyWdkhtS+LBEqRw2bL5qNteMvU2GhqPgFtYQPzolGbw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.4.0.tgz",
+      "integrity": "sha512-scsQO3rSNNKcPHp56Wy5OeZiIpQNmmZOORz8bkQKWjzvzycAodtSWmAoHiMFAKSleR1NyeRIz642fReqlZU9tw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.1.5",

--- a/example/package.json
+++ b/example/package.json
@@ -12,9 +12,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@stacks/clarinet-sdk": "^3.15.0",
+    "@stacks/clarinet-sdk": "^3.18.1",
     "@stacks/rendezvous": "^0.14.0",
-    "@stacks/transactions": "^7.2.0",
+    "@stacks/transactions": "^7.4.0",
     "@types/node": "^24.10.0",
     "chokidar-cli": "^3.0.0",
     "vitest": "^4.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0-rc.1",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@stacks/clarinet-sdk": "^3.16.0",
-        "@stacks/transactions": "^7.3.1",
+        "@stacks/clarinet-sdk": "^3.18.1",
+        "@stacks/transactions": "^7.4.0",
         "ansicolor": "^2.0.3",
         "fast-check": "^4.5.3"
       },
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
-        "@stacks/clarinet-sdk-wasm": "^3.16.0",
+        "@stacks/clarinet-sdk-wasm": "^3.18.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.6.0",
         "jest": "^30.2.0",
@@ -1453,12 +1453,12 @@
       }
     },
     "node_modules/@stacks/clarinet-sdk": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.16.0.tgz",
-      "integrity": "sha512-IhKXuEQnq8vfh97f3R05IHJlUqzT6kOcyWAihOgpb+Ap7t/OA2aCQQfsz4qXonnFXxA1uzojihFAMigMZ/VfNA==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.18.1.tgz",
+      "integrity": "sha512-qrtPK9rAFib1gJ5sz7XQeQe2CuMEuJrsYknK/nFPmoEjw8H8jOJ5UTYGeLKb+wag+kDCb5xKm38tgT6guxsBMg==",
       "license": "GPL-3.0",
       "dependencies": {
-        "@stacks/clarinet-sdk-wasm": "15.16.0",
+        "@stacks/clarinet-sdk-wasm": "3.18.1",
         "@stacks/transactions": "7.4.0",
         "kolorist": "1.8.0",
         "prompts": "2.4.2",
@@ -1469,16 +1469,9 @@
       }
     },
     "node_modules/@stacks/clarinet-sdk-wasm": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.16.0.tgz",
-      "integrity": "sha512-nDyE8DJPuv4OgIcOh94l0YtJ433v7EsuFPfJ3vI1qb98orsXrlEWmjPtXzZzpUtUvM/SPD3PYGUMcffhB/jlfw==",
-      "dev": true,
-      "license": "GPL-3.0"
-    },
-    "node_modules/@stacks/clarinet-sdk/node_modules/@stacks/clarinet-sdk-wasm": {
-      "version": "15.16.0",
-      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-15.16.0.tgz",
-      "integrity": "sha512-OBffQar1BSw0EZ9vnXeSLuVw4O0qfiFgcsSWcDvjybWOew41lUmSLa0QDwbfnKW0tmw2WAC6fDzzHZGQnhHWgg==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.18.1.tgz",
+      "integrity": "sha512-yOOIrvtIL2LKmoWqxR11Y7G7AseOnb5v1eA2kfxtf4UW0mEGAqI2esYoZLi4hXZ7LwhUsHdXPVpTjlWKitD+gA==",
       "license": "GPL-3.0"
     },
     "node_modules/@stacks/clarinet-sdk/node_modules/ansi-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2189,9 +2189,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4741,9 +4741,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,14 +44,14 @@
     "access": "public"
   },
   "dependencies": {
-    "@stacks/clarinet-sdk": "^3.16.0",
-    "@stacks/transactions": "^7.3.1",
+    "@stacks/clarinet-sdk": "^3.18.1",
+    "@stacks/transactions": "^7.4.0",
     "ansicolor": "^2.0.3",
     "fast-check": "^4.5.3"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
-    "@stacks/clarinet-sdk-wasm": "^3.16.0",
+    "@stacks/clarinet-sdk-wasm": "^3.18.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.6.0",
     "jest": "^30.2.0",


### PR DESCRIPTION
This PR updates `@stacks/clarinet-sdk`, `@stacks/clarinet-sdk-wasm`, and `@stacks/transactions` to their latest versions. It also removes a link that was not rendering from the docs.