### PR TITLE
Post-transfer fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           rv . rendezvous-token invariant --dial=./sip010.cjs
           rv . counter test --config=rv.config.json
 
-  generate-docs:
+  build-docs:
     needs: [tests, examples]
     runs-on: ubuntu-latest
     steps:
@@ -110,34 +110,29 @@ jobs:
           mdbook-version: "0.5.0"
 
       - name: Build docs
-        run: |
-          mdbook build docs
+        run: mdbook build docs
 
-      - name: Deploy to GitHub Pages
-        # Only deploy docs if the push is to the master branch.
+      - name: Configure Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        run: |
-          # Configure Git to commit to gh-pages branch.
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'actions@github.com'
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
-          # The gh-pages branch has no meaningful history since it's completely
-          # regenerated from scratch on each commit to master. History would be
-          # noise, not signal. The source of truth is the master branch and the
-          # build system, making the gh-pages content purely ephemeral output.
-          # Force pushing an orphan branch gives us exactly what we need: clean
-          # snapshot of the documentation at each point in time without all the
-          # baggage of incorrect or outdated history.
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: docs/dist
 
-          # Create orphan branch (no history).
-          git checkout --orphan gh-pages
-          # Remove all files from the working tree.
-          git rm -rf .
-          # Copy the built site to the root.
-          cp -r docs/dist/* .
-          # Add all files.
-          git add .
-          # Commit with empty message (since no history on gh-pages anyways).
-          git commit --allow-empty-message -m ''
-          # Force push to gh-pages branch (again since no history).
-          git push origin gh-pages --force
+  deploy-docs:
+    needs: [build-docs]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Real bugs and security vulnerabilities uncovered with `rv`. To add a finding, op
 
 ### Documentation
 
-For full documentation, see the official [Rendezvous Book](https://stacks-network.github.io/rendezvous/).
+For full documentation, see the official [Rendezvous Book](https://stx-labs.github.io/rendezvous/).
 
 ---
 

--- a/cli.ts
+++ b/cli.ts
@@ -29,7 +29,7 @@ export const helpMessage = `
     --bail        Stop on first failure
     -h, --help    Show this message
 
-  Learn more: https://stacks-network.github.io/rendezvous/
+  Learn more: https://stx-labs.github.io/rendezvous/
   `;
 
 /**

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -9,5 +9,5 @@ build-dir = "dist"
 
 [output.html]
 additional-css = ["custom.css"]
-edit-url-template = "https://github.com/stacks-network/rendezvous/blob/master/docs/{path}"
-git-repository-url = "https://github.com/stacks-network/rendezvous/"
+edit-url-template = "https://github.com/stx-labs/rendezvous/blob/master/docs/{path}"
+git-repository-url = "https://github.com/stx-labs/rendezvous/"

--- a/docs/chapter_5.md
+++ b/docs/chapter_5.md
@@ -64,7 +64,7 @@ If you want to contribute to Rendezvous or run it from source:
 1. Clone the repository:
 
    ```bash
-   git clone https://github.com/stacks-network/rendezvous.git
+   git clone https://github.com/stx-labs/rendezvous.git
    ```
 
 2. Navigate to the project directory:

--- a/docs/chapter_6.md
+++ b/docs/chapter_6.md
@@ -588,7 +588,7 @@ Some smart contracts need a special `Clarinet.toml` file to allow Rendezvous to 
 
 A great example is the **sBTC contract suite**.
 
-For testing the [`sbtc-token`](https://github.com/stacks-network/sbtc/blob/b624e4a8f08eb589a435719b200873e8aa5b3305/contracts/contracts/sbtc-token.clar#L30-L35) contract, the `sbtc-registry` authorization function [`is-protocol-caller`](https://github.com/stacks-network/sbtc/blob/b624e4a8f08eb589a435719b200873e8aa5b3305/contracts/contracts/sbtc-registry.clar#L361-L369) is **too restrictive**. Normally, it only allows calls from protocol contracts, making it **impossible to directly test certain state transitions** in `sbtc-token`.
+For testing the [`sbtc-token`](https://github.com/stacks-sbtc/sbtc/blob/b624e4a8f08eb589a435719b200873e8aa5b3305/contracts/contracts/sbtc-token.clar#L30-L35) contract, the `sbtc-registry` authorization function [`is-protocol-caller`](https://github.com/stacks-sbtc/sbtc/blob/b624e4a8f08eb589a435719b200873e8aa5b3305/contracts/contracts/sbtc-registry.clar#L361-L369) is **too restrictive**. Normally, it only allows calls from protocol contracts, making it **impossible to directly test certain state transitions** in `sbtc-token`.
 
 To work around this, you need two things:
 

--- a/docs/chapter_6.md
+++ b/docs/chapter_6.md
@@ -195,7 +195,7 @@ Dialers allow you to define **pre- and post-execution functions** using JavaScri
 rv root contract invariant --dial=./custom-dialer.js
 ```
 
-A good example of a dialer can be found in the Rendezvous repository, within the example Clarinet project, inside the [sip010.cjs file](https://github.com/stacks-network/rendezvous/blob/12b3e4cc011c0029522b54e0e02342f9d47600eb/example/sip010.cjs).
+A good example of a dialer can be found in the Rendezvous repository, within the example Clarinet project, inside the [sip010.cjs file](https://github.com/stx-labs/rendezvous/blob/12b3e4cc011c0029522b54e0e02342f9d47600eb/example/sip010.cjs).
 
 In that file, you’ll find a **post-dialer** designed as a **sanity check** for SIP-010 token contracts. It ensures that the `transfer` function correctly emits the required **print event** containing the `memo`, as specified in [SIP-010](https://github.com/stacksgov/sips/blob/6ea251726353bd1ad1852aabe3d6cf1ebfe02830/sips/sip-010/sip-010-fungible-token-standard.md?plain=1#L69).
 
@@ -659,9 +659,9 @@ This process allows Rendezvous to create meaningful state transitions and valida
 
 ### Example
 
-The `example` Clarinet project demonstrates this feature. The [send-tokens](https://github.com/stacks-network/rendezvous/blob/1e9fe78b07d8cd971843634f3915186295efb414/example/contracts/send-tokens.clar) contract contains one public function and one property-based test that both accept trait references.
+The `example` Clarinet project demonstrates this feature. The [send-tokens](https://github.com/stx-labs/rendezvous/blob/1e9fe78b07d8cd971843634f3915186295efb414/example/contracts/send-tokens.clar) contract contains one public function and one property-based test that both accept trait references.
 
-To enable testing, the project includes [rendezvous-token](https://github.com/stacks-network/rendezvous/blob/1e9fe78b07d8cd971843634f3915186295efb414/example/contracts/rendezvous-token.clar), which implements the required trait.
+To enable testing, the project includes [rendezvous-token](https://github.com/stx-labs/rendezvous/blob/1e9fe78b07d8cd971843634f3915186295efb414/example/contracts/rendezvous-token.clar), which implements the required trait.
 
 ### Adding More Implementations
 

--- a/docs/chapter_7.md
+++ b/docs/chapter_7.md
@@ -672,10 +672,10 @@ Now that you understand the power of Rendezvous, explore:
 
 ## Get Involved
 
-**Found this tutorial useful?** Star the [Rendezvous repository on GitHub](https://github.com/stacks-network/rendezvous) to show your support!
+**Found this tutorial useful?** Star the [Rendezvous repository on GitHub](https://github.com/stx-labs/rendezvous) to show your support!
 
 Have questions, found a bug, or want to contribute? We'd love to hear from you:
 
-- **Open an issue** on [GitHub](https://github.com/stacks-network/rendezvous/issues)
+- **Open an issue** on [GitHub](https://github.com/stx-labs/rendezvous/issues)
 - **Reach out** with questions or feedback
 - **Share your findings** — contribute examples of bugs you've caught to show others how powerful advanced testing techniques can be

--- a/example/sip010.cjs
+++ b/example/sip010.cjs
@@ -4,14 +4,14 @@
 //
 // This is just an example of the power of custom dialers. In sBTC, the
 // transfer function did not emit the print event, resulting in sBTC not being
-// SIP-010 compliant: https://github.com/stacks-network/sbtc/issues/1090.
+// SIP-010 compliant: https://github.com/stacks-sbtc/sbtc/issues/1090.
 //
 // This custom dialer allows for the detection of such issues for any fungible
 // token contract in the future.
 //
 // References:
 // https://github.com/stacksgov/sips/blob/2c3b36c172c0b71369bc26cffa080e8bdd2b3b84/sips/sip-010/sip-010-fungible-token-standard.md?plain=1#L69
-// https://github.com/stacks-network/sbtc/commit/74daed379e9aad73dd09bebb83231f2c48ef4d81
+// https://github.com/stacks-sbtc/sbtc/commit/74daed379e9aad73dd09bebb83231f2c48ef4d81
 
 async function postTransferSip010PrintEvent(context) {
   const selectedFunction = context.selectedFunction;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stacks-network/rendezvous.git"
+    "url": "git+https://github.com/stx-labs/rendezvous.git"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR fixes links after transfer to stx-labs. It also updates the docs publishing-related jobs to use the native GH Pages actions (previous jobs stopped deploying at some point in the past due to the lack of a Jekyll build).