### PR TITLE
Update example project to use @stacks/rendezvous@1.0.1

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@stacks/clarinet-sdk": "^3.20.0",
-        "@stacks/rendezvous": "^1.0.0",
+        "@stacks/rendezvous": "^1.0.1",
         "@stacks/transactions": "^7.4.0",
         "@types/node": "^24.10.0",
         "chokidar-cli": "^3.0.0",
@@ -435,12 +435,12 @@
       }
     },
     "node_modules/@stacks/rendezvous": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@stacks/rendezvous/-/rendezvous-1.0.0.tgz",
-      "integrity": "sha512-d+USR0p11zQg68VgFQ1cPhH9Zf5cdLFEBPyXkPDRIJt8M51LP9F616kiXQUINkD/8zPDhJFHg4vx5FPn5i9NNQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stacks/rendezvous/-/rendezvous-1.0.1.tgz",
+      "integrity": "sha512-bXyK504/rnvZiMvWVeVbjEW1b5xXuWYOcSIFFZzt9tP84GdW0viSD6UuElFJzTvqisUFvFYDgFJQnbH21Uhctg==",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@stacks/clarinet-sdk": "^3.18.1",
+        "@stacks/clarinet-sdk": "^3.20.0",
         "@stacks/transactions": "^7.4.0",
         "ansicolor": "^2.0.3",
         "fast-check": "^4.5.3"

--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@stacks/clarinet-sdk": "^3.20.0",
-    "@stacks/rendezvous": "^1.0.0",
+    "@stacks/rendezvous": "^1.0.1",
     "@stacks/transactions": "^7.4.0",
     "@types/node": "^24.10.0",
     "chokidar-cli": "^3.0.0",


### PR DESCRIPTION
This post-release PR updates the example Clarinet project to use the latest Rendezvous version.

Manually-generated after release 1.0.1, as a follow-up on this [job failure](https://github.com/stx-labs/rendezvous/actions/runs/27970912851/job/82979316669) caused by new signed commits repository requirement after stx-labs migration.